### PR TITLE
Edits

### DIFF
--- a/K2Field.K2NE.ServiceBroker/Constants/ErrorMessages.cs
+++ b/K2Field.K2NE.ServiceBroker/Constants/ErrorMessages.cs
@@ -20,7 +20,8 @@ namespace K2Field.K2NE.ServiceBroker.Constants
         public const string ZoneDoesNotExist = "Time Zone does not exist. Name: ";
         public const string DateNotValid = "Time Zone does not exist. Name: The string could not be parsed into a valid date and time.";
         public const string WorkingHoursNotSet = "No working hours have been set. Please set the working hours using the K2 Workspace.";
+        //Out Of Office
+        public const string OutOfOfficeNotConfiguredForUser = "User does not have out of office configured.  Please configure the users out of office settings.";
+        public const string MultipleOOFConfigurations = "Multiple OOF scenarios detected for this user which is supported by this method.";
     }
-
-
 }

--- a/K2Field.K2NE.ServiceBroker/Constants/ErrorMessages.cs
+++ b/K2Field.K2NE.ServiceBroker/Constants/ErrorMessages.cs
@@ -11,6 +11,15 @@ namespace K2Field.K2NE.ServiceBroker.Constants
         public const string PropertyNotFound = "The property with name '{0}', could not be found.";
         public const string RoleNotExists = "The given role does not exist.";
         public const string RoleTypeNotSupported = "Role Type is not supported. Only User and group allowed.";
+
+        //Error messages for WorkingHoursConfiguration ServiceObject
+        public const string DayOfWeekNotFound = "The Day of Week not found. Please, use English variants: Monday, Tuesday...";
+        public const string GMTOffSetValidationFailed = "GMTOffset must be between -13 and 13";
+        public const string ZoneExists = "Time Zone already exists. Name: ";
+        public const string SpecialCharactersAreNotAllowed = "Special characters are not allowed.";
+        public const string ZoneDoesNotExist = "Time Zone does not exist. Name: ";
+        public const string DateNotValid = "Time Zone does not exist. Name: The string could not be parsed into a valid date and time.";
+        public const string WorkingHoursNotSet = "No working hours have been set. Please set the working hours using the K2 Workspace.";
     }
 
 

--- a/K2Field.K2NE.ServiceBroker/Constants/Methods.cs
+++ b/K2Field.K2NE.ServiceBroker/Constants/Methods.cs
@@ -58,5 +58,27 @@ namespace K2Field.K2NE.ServiceBroker.Constants
             public const string GetUserDetails = "GetUserDetails";
             public const string SearchUsers = "SearchUsers";
         }
+
+        public static class WorkingHoursConfiguration
+        {
+            public const string CreateZone = "CreateZone";
+            public const string SaveZone = "SaveZone";
+            public const string LoadZone = "LoadZone";
+            public const string DeleteZone = "DeleteZone";
+            public const string ListZones = "ListZones";
+            public const string ListZoneUsers = "ListZoneUsers";
+            public const string GetDefaultZone = "GetDefaultZone";
+            public const string SetDefaultZone = "SetDefaultZone";
+            public const string ZoneExists = "ZoneExists";
+            public const string ZoneCalculateEvent = "ZoneCalculateEvent";
+            public const string UserSetZone = "UserSetZone";
+            public const string UserGetZone = "UserGetZone";
+            public const string UserDeleteZone = "UserDeleteZone";
+            public const string UserCalculateEvent = "UserCalculateEvent";
+            
+            //TODO: Later if needed
+            public const string ListZoneWorkingHours = "ListZoneWorkingHours";
+            public const string ListZoneAvailabilityDates = "ListZoneAvailabilityDates";
+        }
     }
 }

--- a/K2Field.K2NE.ServiceBroker/Constants/Methods.cs
+++ b/K2Field.K2NE.ServiceBroker/Constants/Methods.cs
@@ -80,5 +80,13 @@ namespace K2Field.K2NE.ServiceBroker.Constants
             public const string ListZoneWorkingHours = "ListZoneWorkingHours";
             public const string ListZoneAvailabilityDates = "ListZoneAvailabilityDates";
         }
+        public static class OutOfOffice
+        {
+            public const string SetOutOfOffice = "SetOutOfOffice";
+            public const string SetInOffice = "SetInOffice";
+            public const string ListSharedUsers = "ListSharedUsers";
+            public const string AddOutOfOffice = "AddOutOfOffice";
+            public const string GetUserStatus = "GetUserStatus";
+        }
     }
 }

--- a/K2Field.K2NE.ServiceBroker/Constants/Properties.cs
+++ b/K2Field.K2NE.ServiceBroker/Constants/Properties.cs
@@ -172,5 +172,14 @@ namespace K2Field.K2NE.ServiceBroker.Constants
                 public const string StartDateTime = "StartDateTime";
                 public const string FinishDateTime = "FinishDateTime";
             }
+
+            public static class OutOfOffice
+            {
+                public const string UserFQN = "UserFQN";
+                public const string UserStatus = "UserStatus";
+                public const string CallSuccess = "CallSuccess";
+                public const string DestinationUser = "DestinationUser";
+
+            }
     }
 }

--- a/K2Field.K2NE.ServiceBroker/Constants/Properties.cs
+++ b/K2Field.K2NE.ServiceBroker/Constants/Properties.cs
@@ -136,6 +136,41 @@ namespace K2Field.K2NE.ServiceBroker.Constants
 
 
                 public static string MaxSearchResultSize = "MaxResultSize";
+
+            }
+
+            public static class WorkingHoursConfiguration
+            {
+                public const string ZoneName = "ZoneName";
+                public const string NewZoneName = "NewZoneName";
+                public const string ZoneGUID = "ZoneGUID";
+                public const string Description = "Description";
+                public const string GMTOffset = "GMTOffset";
+                public const string DefaultZone = "DefaultZone";
+                
+                public const string DurationHours = "DurationHours";
+                public const string DurationMinutes = "DurationMinutes";
+                public const string DurationSeconds = "DurationSeconds";
+                public const string TimeOfDayHours = "TimeOfDayHours";
+                public const string TimeOfDayMinutes = "TimeOfDayMinutes";
+                public const string TimeOfDaySeconds = "TimeOfDaySeconds";
+                public const string WorkDay = "WorkDay";
+                
+                //public const string Description = "Description";
+                //public const string AvailabilityDateDurationDays = "AvailabilityHoursTimeOfDayDays";
+                //public const string AvailabilityDateDurationHours = "AvailabilityDateDurationHours";
+                //public const string AvailabilityDateDurationMinutes = "AvailabilityDateDurationMinutes";
+                //public const string AvailabilityDateDurationSeconds = "AvailabilityDateDurationSeconds";
+                public const string IsNonWorkDate = "IsNonWorkDate";
+                //public const string AvailabilityDateTimeOfDayHours = "AvailabilityDateTimeOfDayHours";
+                //public const string AvailabilityDateTimeOfDayMinutes = "AvailabilityDateTimeOfDayMinutes";
+                //public const string AvailabilityDateTimeOfDaySeconds = "AvailabilityDateTimeOfDaySeconds";
+                public const string WorkDate = "WorkDate";
+                public const string FQN = "FQN";
+                public const string UserName = "UserName";
+                public const string ZoneExists = "ZoneExists";
+                public const string StartDateTime = "StartDateTime";
+                public const string FinishDateTime = "FinishDateTime";
             }
     }
 }

--- a/K2Field.K2NE.ServiceBroker/Helper.cs
+++ b/K2Field.K2NE.ServiceBroker/Helper.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using SourceCode.SmartObjects.Services.ServiceSDK.Objects;
 using SourceCode.SmartObjects.Services.ServiceSDK.Types;
+using System.Text.RegularExpressions;
 
 namespace K2Field.K2NE.ServiceBroker
 {
@@ -126,6 +127,25 @@ namespace K2Field.K2NE.ServiceBroker
             so.Active = true;
             return so;
         }
-
+        /// <summary>
+        /// Check if special characters exist in ZoneName
+        /// </summary>
+        /// <param name="zoneName">Name of a zone</param>
+        /// <returns></returns>
+        public static bool SpecialCharactersExist (string zoneName)
+        {
+            Regex pattern = new Regex(@"^[a-zA-Z0-9]*$");
+            return pattern.IsMatch(zoneName);
+        }
+        /// <summary>
+        /// Deletes the Label from FQN
+        /// </summary>
+        /// <param name="FQN">Fully Qualified Name</param>
+        /// <returns></returns>
+        public static string DeleteLabel (string FQN)
+        {
+            char[] delimiterChars = {':'};
+            return FQN.Split(delimiterChars)[1];
+        }
     }
 }

--- a/K2Field.K2NE.ServiceBroker/K2Field.K2NE.ServiceBroker.csproj
+++ b/K2Field.K2NE.ServiceBroker/K2Field.K2NE.ServiceBroker.csproj
@@ -92,6 +92,7 @@
     <Compile Include="ServiceObjects\ErrorLogSO.cs" />
     <Compile Include="ServiceObjects\IdentitySO.cs" />
     <Compile Include="ServiceObjects\ManagementWorklistSO.cs" />
+    <Compile Include="ServiceObjects\OutOfOfficeSO.cs" />
     <Compile Include="ServiceObjects\ProcessInstanceManagementSO.cs" />
     <Compile Include="ServiceObjects\RoleSO.cs" />
     <Compile Include="ServiceObjects\WorkingHoursConfigurationSO.cs" />
@@ -105,7 +106,9 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>if "Debug"=="$(ConfigurationName)" (
+net stop "K2 blackpearl Server"
   xcopy /R /Y "$(TargetPath)" "c:\Program Files (x86)\K2 blackpearl\ServiceBroker\"
+net start "K2 blackpearl Server"
 )
 
 if "Release"=="$(ConfigurationName)" (

--- a/K2Field.K2NE.ServiceBroker/K2Field.K2NE.ServiceBroker.csproj
+++ b/K2Field.K2NE.ServiceBroker/K2Field.K2NE.ServiceBroker.csproj
@@ -94,6 +94,7 @@
     <Compile Include="ServiceObjects\ManagementWorklistSO.cs" />
     <Compile Include="ServiceObjects\ProcessInstanceManagementSO.cs" />
     <Compile Include="ServiceObjects\RoleSO.cs" />
+    <Compile Include="ServiceObjects\WorkingHoursConfigurationSO.cs" />
     <Compile Include="ServiceObjects\WorklistSO.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/K2Field.K2NE.ServiceBroker/K2NEServiceBroker.cs
+++ b/K2Field.K2NE.ServiceBroker/K2NEServiceBroker.cs
@@ -37,6 +37,7 @@ namespace K2Field.K2NE.ServiceBroker
                             serviceObjects.Add(new ProcessInstanceManagementSO(this));
                             serviceObjects.Add(new RoleManagementSO(this));
                             serviceObjects.Add(new ActiveDirectorySO(this));
+                            serviceObjects.Add(new WorkingHoursConfigurationSO(this));
                         }
                     }
                 }
@@ -82,7 +83,7 @@ namespace K2Field.K2NE.ServiceBroker
                     return sf;
             }
             ServiceFolder newSf = new ServiceFolder(folderName, new MetaData(folderName, description));
-            this.Service.ServiceFolders.Add(newSf);
+            this.Service.ServiceFolders.Create(newSf);
             return newSf;
         }
 
@@ -121,7 +122,7 @@ namespace K2Field.K2NE.ServiceBroker
             {
                 foreach (ServiceObject so in entry.DescribeServiceObjects())
                 {
-                    this.Service.ServiceObjects.Add(so);
+                    this.Service.ServiceObjects.Create(so);
                     if (requireServiceFolders) {
                         ServiceFolder sf = InitializeServiceFolder(entry.ServiceFolder, entry.ServiceFolder);
                         sf.Add(so);

--- a/K2Field.K2NE.ServiceBroker/K2NEServiceBroker.cs
+++ b/K2Field.K2NE.ServiceBroker/K2NEServiceBroker.cs
@@ -34,6 +34,7 @@ namespace K2Field.K2NE.ServiceBroker
                             serviceObjects.Add(new ErrorLogSO(this));
                             serviceObjects.Add(new IdentitySO(this));
                             serviceObjects.Add(new WorklistSO(this));
+                            serviceObjects.Add(new OutOfOfficeSO(this));
                             serviceObjects.Add(new ProcessInstanceManagementSO(this));
                             serviceObjects.Add(new RoleManagementSO(this));
                             serviceObjects.Add(new ActiveDirectorySO(this));

--- a/K2Field.K2NE.ServiceBroker/Properties/AssemblyInfo.cs
+++ b/K2Field.K2NE.ServiceBroker/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
+
 [assembly: AssemblyVersion("1.1.5.0")]
-[assembly: AssemblyFileVersion("1.1.5.0")]

--- a/K2Field.K2NE.ServiceBroker/ServiceObjects/ActiveDirectorySO.cs
+++ b/K2Field.K2NE.ServiceBroker/ServiceObjects/ActiveDirectorySO.cs
@@ -30,17 +30,17 @@ namespace K2Field.K2NE.ServiceBroker
         {
             ServiceObject soUser = Helper.CreateServiceObject("AD User", "Active Directory User.");
 
-            soUser.Properties.Add(Helper.CreateProperty(Constants.Properties.ActiveDirectory.SubStringSearchInput, SoType.Text, "The string used to search for a specific value."));
-            soUser.Properties.Add(Helper.CreateProperty(Constants.Properties.ActiveDirectory.UserFQN, SoType.Text, "The FQN username. Domain\\samlaccountname"));
-            soUser.Properties.Add(Helper.CreateProperty(Constants.Properties.ActiveDirectory.SamAccountName, SoType.Text, "The SAM Account name"));
-            soUser.Properties.Add(Helper.CreateProperty(Constants.Properties.ActiveDirectory.DisplayName, SoType.Text, "Display Name"));
-            soUser.Properties.Add(Helper.CreateProperty(Constants.Properties.ActiveDirectory.CommonName, SoType.Text, "The common name of the object."));
-            soUser.Properties.Add(Helper.CreateProperty(Constants.Properties.ActiveDirectory.GivenName, SoType.Text, "Given Name"));
-            soUser.Properties.Add(Helper.CreateProperty(Constants.Properties.ActiveDirectory.Initials, SoType.Text, "Initials"));
-            soUser.Properties.Add(Helper.CreateProperty(Constants.Properties.ActiveDirectory.Surname, SoType.Text, "Surname"));
-            soUser.Properties.Add(Helper.CreateProperty(Constants.Properties.ActiveDirectory.Email, SoType.Text, "Email Address"));
-            soUser.Properties.Add(Helper.CreateProperty(Constants.Properties.ActiveDirectory.MaxSearchResultSize, SoType.Number, "Override the default max result size."));
-            soUser.Properties.Add(Helper.CreateProperty(Constants.Properties.ActiveDirectory.OrganisationalUnit, SoType.Text, "OrganisationalUnit"));
+            soUser.Properties.Create(Helper.CreateProperty(Constants.Properties.ActiveDirectory.SubStringSearchInput, SoType.Text, "The string used to search for a specific value."));
+            soUser.Properties.Create(Helper.CreateProperty(Constants.Properties.ActiveDirectory.UserFQN, SoType.Text, "The FQN username. Domain\\samlaccountname"));
+            soUser.Properties.Create(Helper.CreateProperty(Constants.Properties.ActiveDirectory.SamAccountName, SoType.Text, "The SAM Account name"));
+            soUser.Properties.Create(Helper.CreateProperty(Constants.Properties.ActiveDirectory.DisplayName, SoType.Text, "Display Name"));
+            soUser.Properties.Create(Helper.CreateProperty(Constants.Properties.ActiveDirectory.CommonName, SoType.Text, "The common name of the object."));
+            soUser.Properties.Create(Helper.CreateProperty(Constants.Properties.ActiveDirectory.GivenName, SoType.Text, "Given Name"));
+            soUser.Properties.Create(Helper.CreateProperty(Constants.Properties.ActiveDirectory.Initials, SoType.Text, "Initials"));
+            soUser.Properties.Create(Helper.CreateProperty(Constants.Properties.ActiveDirectory.Surname, SoType.Text, "Surname"));
+            soUser.Properties.Create(Helper.CreateProperty(Constants.Properties.ActiveDirectory.Email, SoType.Text, "Email Address"));
+            soUser.Properties.Create(Helper.CreateProperty(Constants.Properties.ActiveDirectory.MaxSearchResultSize, SoType.Number, "Override the default max result size."));
+            soUser.Properties.Create(Helper.CreateProperty(Constants.Properties.ActiveDirectory.OrganisationalUnit, SoType.Text, "OrganisationalUnit"));
 
 
 
@@ -54,7 +54,7 @@ namespace K2Field.K2NE.ServiceBroker
             mGetUsers.ReturnProperties.Add(Constants.Properties.ActiveDirectory.SamAccountName);
             mGetUsers.ReturnProperties.Add(Constants.Properties.ActiveDirectory.DisplayName);
             mGetUsers.ReturnProperties.Add(Constants.Properties.ActiveDirectory.Email);
-            soUser.Methods.Add(mGetUsers);
+            soUser.Methods.Create(mGetUsers);
 
 
             Method mGetUserDetails = Helper.CreateMethod(Constants.Methods.ActiveDirectory.GetUserDetails, "Get all details for the users.", MethodType.Read);
@@ -68,7 +68,7 @@ namespace K2Field.K2NE.ServiceBroker
             mGetUserDetails.ReturnProperties.Add(Constants.Properties.ActiveDirectory.Surname);
             mGetUserDetails.ReturnProperties.Add(Constants.Properties.ActiveDirectory.Email);
             mGetUserDetails.ReturnProperties.Add(Constants.Properties.ActiveDirectory.OrganisationalUnit);
-            soUser.Methods.Add(mGetUserDetails);
+            soUser.Methods.Create(mGetUserDetails);
 
 
             Method mSearchUser = Helper.CreateMethod(Constants.Methods.ActiveDirectory.SearchUsers, "Performs a StartWith query on DisplayName, SamlAccountName and E-mail.", MethodType.List);
@@ -80,7 +80,7 @@ namespace K2Field.K2NE.ServiceBroker
             mSearchUser.ReturnProperties.Add(Constants.Properties.ActiveDirectory.SamAccountName);
             mSearchUser.ReturnProperties.Add(Constants.Properties.ActiveDirectory.DisplayName);
             mSearchUser.ReturnProperties.Add(Constants.Properties.ActiveDirectory.Email);
-            soUser.Methods.Add(mSearchUser);
+            soUser.Methods.Create(mSearchUser);
 
 
             return new List<ServiceObject>() { soUser };

--- a/K2Field.K2NE.ServiceBroker/ServiceObjects/ErrorLogSO.cs
+++ b/K2Field.K2NE.ServiceBroker/ServiceObjects/ErrorLogSO.cs
@@ -18,15 +18,15 @@ namespace K2Field.K2NE.ServiceBroker
         public override List<ServiceObject> DescribeServiceObjects()
 {
             ServiceObject so = Helper.CreateServiceObject("ErrorLog", "Service Object that exposes the ErrorLog of the K2 server.");
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ErrorLog.Profile, SoType.Text, "The error profile to return, default 'All'"));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ErrorLog.ProcessInstanceId, SoType.Number, "The errored process id."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ErrorLog.ProcessName, SoType.Text, "The errored process name."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ErrorLog.Folio, SoType.Text, "The folio of the errored process."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ErrorLog.ErrorDescription, SoType.Text, "The description/exception of the error."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ErrorLog.ErrorItem, SoType.Text, "The item that has errored (event)."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ErrorLog.ErrorId, SoType.Number, "The Identified for the error log"));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ErrorLog.ErrorDate, SoType.DateTime, "Date when the error occured"));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ErrorLog.TryNewVersion, SoType.YesNo, "retry the error in new version."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ErrorLog.Profile, SoType.Text, "The error profile to return, default 'All'"));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ErrorLog.ProcessInstanceId, SoType.Number, "The errored process id."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ErrorLog.ProcessName, SoType.Text, "The errored process name."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ErrorLog.Folio, SoType.Text, "The folio of the errored process."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ErrorLog.ErrorDescription, SoType.Text, "The description/exception of the error."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ErrorLog.ErrorItem, SoType.Text, "The item that has errored (event)."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ErrorLog.ErrorId, SoType.Number, "The Identified for the error log"));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ErrorLog.ErrorDate, SoType.DateTime, "Date when the error occured"));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ErrorLog.TryNewVersion, SoType.YesNo, "retry the error in new version."));
 
 
             Method getErrors = Helper.CreateMethod(Constants.Methods.ErrorLog.GetErrors, "Retrieve the K2 error log", MethodType.List);
@@ -38,13 +38,13 @@ namespace K2Field.K2NE.ServiceBroker
             getErrors.ReturnProperties.Add(Constants.Properties.ErrorLog.ErrorItem);
             getErrors.ReturnProperties.Add(Constants.Properties.ErrorLog.ErrorDate);
             getErrors.ReturnProperties.Add(Constants.Properties.ErrorLog.ErrorId);
-            so.Methods.Add(getErrors);
+            so.Methods.Create(getErrors);
 
             Method retryProcess = Helper.CreateMethod(Constants.Methods.ErrorLog.RetryProcess, "Retry a process instance", MethodType.Execute);
             retryProcess.InputProperties.Add(Constants.Properties.ErrorLog.ProcessInstanceId);
             retryProcess.Validation.RequiredProperties.Add(Constants.Properties.ErrorLog.ProcessInstanceId);
             retryProcess.InputProperties.Add(Constants.Properties.ErrorLog.TryNewVersion);
-            so.Methods.Add(retryProcess);
+            so.Methods.Create(retryProcess);
 
             return new List<ServiceObject> { so };
         }

--- a/K2Field.K2NE.ServiceBroker/ServiceObjects/IdentitySO.cs
+++ b/K2Field.K2NE.ServiceBroker/ServiceObjects/IdentitySO.cs
@@ -21,21 +21,21 @@ namespace K2Field.K2NE.ServiceBroker
             ServiceObject so = Helper.CreateServiceObject("Identity", "Useful methods to determine the identities being used.");
 
 
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.Identity.CurrentPrincipalAuthType, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.Text, "The current principal's authentication type"));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.Identity.CurrentPrincipalName, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.Text, "The current principal's authentication identity name."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.Identity.FQN, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.Text, "The K2 FQN of the user."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.Identity.UserDescription, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.Text, "The users description."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.Identity.UserDisplayName, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.Text, "The users displayname."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.Identity.UserEmail, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.Text, "The users email address."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.Identity.UserManager, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.Text, "The users manager."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.Identity.UserName, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.Text, "The users name."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.Identity.UserUserLabel, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.Text, "The users label."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.Identity.CallingFQN, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.Text, "The FQN determined by the service instance."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.Identity.WindowsIdentityAuthType, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.Text, "Windows Identity Authentication Type"));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.Identity.WindowsIdentityName, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.Text, "WIndows Identity Name"));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.Identity.ServiceBrokerAuthType, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.Text, "Service Broker Authentication Type"));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.Identity.ServiceBrokerUserName, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.Text, "Service Broker UserName"));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.Identity.UserWindowsImpersonation, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.YesNo, "Tells the service broker to use (windows) impersonation or not."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.Identity.CurrentPrincipalAuthType, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.Text, "The current principal's authentication type"));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.Identity.CurrentPrincipalName, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.Text, "The current principal's authentication identity name."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.Identity.FQN, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.Text, "The K2 FQN of the user."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.Identity.UserDescription, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.Text, "The users description."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.Identity.UserDisplayName, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.Text, "The users displayname."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.Identity.UserEmail, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.Text, "The users email address."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.Identity.UserManager, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.Text, "The users manager."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.Identity.UserName, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.Text, "The users name."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.Identity.UserUserLabel, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.Text, "The users label."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.Identity.CallingFQN, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.Text, "The FQN determined by the service instance."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.Identity.WindowsIdentityAuthType, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.Text, "Windows Identity Authentication Type"));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.Identity.WindowsIdentityName, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.Text, "WIndows Identity Name"));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.Identity.ServiceBrokerAuthType, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.Text, "Service Broker Authentication Type"));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.Identity.ServiceBrokerUserName, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.Text, "Service Broker UserName"));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.Identity.UserWindowsImpersonation, SourceCode.SmartObjects.Services.ServiceSDK.Types.SoType.YesNo, "Tells the service broker to use (windows) impersonation or not."));
 
 
             Method mGetWorkflowClientIdentity = Helper.CreateMethod(Constants.Methods.Identity.ReadWorkflowClientIdentity, "Retrieve who you are for the K2 Client API", SourceCode.SmartObjects.Services.ServiceSDK.Types.MethodType.Read);
@@ -49,7 +49,7 @@ namespace K2Field.K2NE.ServiceBroker
             mGetWorkflowClientIdentity.ReturnProperties.Add(Constants.Properties.Identity.CallingFQN);
 
             mGetWorkflowClientIdentity.InputProperties.Add(Constants.Properties.Identity.UserWindowsImpersonation);
-            so.Methods.Add(mGetWorkflowClientIdentity);
+            so.Methods.Create(mGetWorkflowClientIdentity);
 
             Method mGetThreadIdentity = Helper.CreateMethod(Constants.Methods.Identity.ReadThreadIdentity, "Retrieve who you are for the API Identity", SourceCode.SmartObjects.Services.ServiceSDK.Types.MethodType.Read);
             mGetThreadIdentity.ReturnProperties.Add(Constants.Properties.Identity.CallingFQN);
@@ -61,7 +61,7 @@ namespace K2Field.K2NE.ServiceBroker
             mGetThreadIdentity.ReturnProperties.Add(Constants.Properties.Identity.ServiceBrokerUserName);
 
             mGetThreadIdentity.InputProperties.Add(Constants.Properties.Identity.UserWindowsImpersonation);
-            so.Methods.Add(mGetThreadIdentity);
+            so.Methods.Create(mGetThreadIdentity);
 
 
             return new List<ServiceObject> { so };

--- a/K2Field.K2NE.ServiceBroker/ServiceObjects/ManagementWorklistSO.cs
+++ b/K2Field.K2NE.ServiceBroker/ServiceObjects/ManagementWorklistSO.cs
@@ -51,23 +51,23 @@ namespace K2Field.K2NE.ServiceBroker
         {
             ServiceObject so = Helper.CreateServiceObject("ManagementWorklist", "Exposes the management worklist.");
 
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ManagementWorklist.ActivityId, SoType.Number, "Activity Id"));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ManagementWorklist.ActivityInstanceDestinationId, SoType.Number, "Activity Instance Destination Id"));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ManagementWorklist.ActivityInstanceId, SoType.Number, "Activity Instance Id"));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ManagementWorklist.ActivityName, SoType.Text, "The name of the activity."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ManagementWorklist.Destination, SoType.Text, "The destination of the worklist item."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ManagementWorklist.DestinationType, SoType.Text, "The type of the destination (user, group, role)"));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ManagementWorklist.EventId, SoType.Number, "Event Id"));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ManagementWorklist.EventName, SoType.Text, "The name of the event."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ManagementWorklist.Folio, SoType.Text, "The process folio."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ManagementWorklist.ProcessInstanceId, SoType.Number, "The process instance ID."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ManagementWorklist.ProcessName, SoType.Text, "The name of the process."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ManagementWorklist.ProcessStatus, SoType.Text, "The status of the process."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ManagementWorklist.StartDate, SoType.DateTime, "The date when the worklist item was created."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ManagementWorklist.WorklistItemStatus, SoType.Text, "The current status of the worklist item."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ManagementWorklist.WorklistItemId, SoType.Number, "The ID of the worklistitem."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ManagementWorklist.FromUser, SoType.Text, "The FQN of the user to redirect/delegate from."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ManagementWorklist.ToUser, SoType.Text, "The FQN of the user to redirect/delegate to."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ManagementWorklist.ActivityId, SoType.Number, "Activity Id"));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ManagementWorklist.ActivityInstanceDestinationId, SoType.Number, "Activity Instance Destination Id"));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ManagementWorklist.ActivityInstanceId, SoType.Number, "Activity Instance Id"));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ManagementWorklist.ActivityName, SoType.Text, "The name of the activity."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ManagementWorklist.Destination, SoType.Text, "The destination of the worklist item."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ManagementWorklist.DestinationType, SoType.Text, "The type of the destination (user, group, role)"));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ManagementWorklist.EventId, SoType.Number, "Event Id"));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ManagementWorklist.EventName, SoType.Text, "The name of the event."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ManagementWorklist.Folio, SoType.Text, "The process folio."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ManagementWorklist.ProcessInstanceId, SoType.Number, "The process instance ID."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ManagementWorklist.ProcessName, SoType.Text, "The name of the process."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ManagementWorklist.ProcessStatus, SoType.Text, "The status of the process."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ManagementWorklist.StartDate, SoType.DateTime, "The date when the worklist item was created."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ManagementWorklist.WorklistItemStatus, SoType.Text, "The current status of the worklist item."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ManagementWorklist.WorklistItemId, SoType.Number, "The ID of the worklistitem."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ManagementWorklist.FromUser, SoType.Text, "The FQN of the user to redirect/delegate from."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ManagementWorklist.ToUser, SoType.Text, "The FQN of the user to redirect/delegate to."));
 
 
 
@@ -87,7 +87,7 @@ namespace K2Field.K2NE.ServiceBroker
             getWorkload.ReturnProperties.Add(Constants.Properties.ManagementWorklist.StartDate);
             getWorkload.ReturnProperties.Add(Constants.Properties.ManagementWorklist.WorklistItemStatus);
             getWorkload.ReturnProperties.Add(Constants.Properties.ManagementWorklist.WorklistItemId);
-            so.Methods.Add(getWorkload);
+            so.Methods.Create(getWorkload);
 
 
 
@@ -97,11 +97,11 @@ namespace K2Field.K2NE.ServiceBroker
             mRedirectWorklistItem.InputProperties.Add(Constants.Properties.ManagementWorklist.ActivityInstanceDestinationId);
             mRedirectWorklistItem.InputProperties.Add(Constants.Properties.ManagementWorklist.FromUser);
             mRedirectWorklistItem.InputProperties.Add(Constants.Properties.ManagementWorklist.ToUser);
-            so.Methods.Add(mRedirectWorklistItem);
+            so.Methods.Create(mRedirectWorklistItem);
 
             Method mReleaseWorklistItem = Helper.CreateMethod(Constants.Methods.ManagementWorklist.ReleaseWorklistItem, "Release the worklistitem slot back into the wild", SourceCode.SmartObjects.Services.ServiceSDK.Types.MethodType.Execute);
             mReleaseWorklistItem.InputProperties.Add(Constants.Properties.ManagementWorklist.WorklistItemId);
-            so.Methods.Add(mReleaseWorklistItem);
+            so.Methods.Create(mReleaseWorklistItem);
 
             return new List<ServiceObject> { so };
         }

--- a/K2Field.K2NE.ServiceBroker/ServiceObjects/OutOfOfficeSO.cs
+++ b/K2Field.K2NE.ServiceBroker/ServiceObjects/OutOfOfficeSO.cs
@@ -1,0 +1,285 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using SourceCode.SmartObjects.Services.ServiceSDK.Objects;
+using SourceCode.SmartObjects.Services.ServiceSDK.Types;
+using SourceCode.Workflow.Management;
+using System.Data;
+
+using SourceCode.Workflow.Management.OOF;
+
+namespace K2Field.K2NE.ServiceBroker
+{
+    class OutOfOfficeSO : ServiceObjectBase
+    {
+        public OutOfOfficeSO(K2NEServiceBroker api) : base(api) { }
+
+        
+        public override string ServiceFolder
+        {
+            get
+            {
+                return "Management API";
+            }
+        }
+        
+        public override List<ServiceObject> DescribeServiceObjects()
+        {
+
+            ServiceObject so = Helper.CreateServiceObject("OutOfOfficeManagement", "Allows for managing user Out Of Offcie status");
+
+            so.Properties.Add(Helper.CreateProperty(Constants.Properties.OutOfOffice.UserFQN, SoType.Text, @"The users FQN with label, ex.'K2:DOMAIN\User' (no quotes)."));
+            so.Properties.Add(Helper.CreateProperty(Constants.Properties.OutOfOffice.DestinationUser, SoType.Text, "User to forward worktask items to"));
+            so.Properties.Add(Helper.CreateProperty(Constants.Properties.OutOfOffice.UserStatus, SoType.Text, "Status of a user"));
+            so.Properties.Add(Helper.CreateProperty(Constants.Properties.OutOfOffice.CallSuccess, SoType.YesNo, "Success of method call"));
+
+            Method setOutOfOffice = Helper.CreateMethod(Constants.Methods.OutOfOffice.SetOutOfOffice, "Set the office status of a user to Out of Office", MethodType.Execute);
+            setOutOfOffice.InputProperties.Add(Constants.Properties.OutOfOffice.UserFQN);
+            setOutOfOffice.Validation.RequiredProperties.Add(Constants.Properties.OutOfOffice.UserFQN);
+            setOutOfOffice.ReturnProperties.Add(Constants.Properties.OutOfOffice.UserFQN);
+            setOutOfOffice.ReturnProperties.Add(Constants.Properties.OutOfOffice.CallSuccess);
+            so.Methods.Add(setOutOfOffice);
+
+            Method setInOffice = Helper.CreateMethod(Constants.Methods.OutOfOffice.SetInOffice, "Set the office status of a users.", MethodType.Execute);
+            setInOffice.InputProperties.Add(Constants.Properties.OutOfOffice.UserFQN);
+            setInOffice.Validation.RequiredProperties.Add(Constants.Properties.OutOfOffice.UserFQN);
+            setInOffice.ReturnProperties.Add(Constants.Properties.OutOfOffice.UserFQN);
+            setInOffice.ReturnProperties.Add(Constants.Properties.OutOfOffice.CallSuccess);
+            so.Methods.Add(setInOffice);
+
+            Method getUserStatus = Helper.CreateMethod(Constants.Methods.OutOfOffice.GetUserStatus, "Get the office status of a user.", MethodType.Read);
+            getUserStatus.InputProperties.Add(Constants.Properties.OutOfOffice.UserFQN);
+            getUserStatus.Validation.RequiredProperties.Add(Constants.Properties.OutOfOffice.UserFQN);
+            getUserStatus.ReturnProperties.Add(Constants.Properties.OutOfOffice.UserStatus);
+            getUserStatus.ReturnProperties.Add(Constants.Properties.OutOfOffice.UserFQN);
+            so.Methods.Add(getUserStatus);
+
+            Method addOutOfOffice = Helper.CreateMethod(Constants.Methods.OutOfOffice.AddOutOfOffice, "Get the office status of a user.", MethodType.Read);
+            addOutOfOffice.InputProperties.Add(Constants.Properties.OutOfOffice.UserFQN);
+            addOutOfOffice.InputProperties.Add(Constants.Properties.OutOfOffice.DestinationUser);
+            addOutOfOffice.Validation.RequiredProperties.Add(Constants.Properties.OutOfOffice.UserFQN);
+            addOutOfOffice.Validation.RequiredProperties.Add(Constants.Properties.OutOfOffice.DestinationUser);
+            addOutOfOffice.ReturnProperties.Add(Constants.Properties.OutOfOffice.UserFQN);
+            addOutOfOffice.ReturnProperties.Add(Constants.Properties.OutOfOffice.DestinationUser);
+            addOutOfOffice.ReturnProperties.Add(Constants.Properties.OutOfOffice.CallSuccess);
+            so.Methods.Add(addOutOfOffice);
+
+            Method listSharedUsers = Helper.CreateMethod(Constants.Methods.OutOfOffice.ListSharedUsers, "Get the destiination users for OOF user", MethodType.List);
+            listSharedUsers.InputProperties.Add(Constants.Properties.OutOfOffice.UserFQN);
+            listSharedUsers.Validation.RequiredProperties.Add(Constants.Properties.OutOfOffice.UserFQN);
+            listSharedUsers.ReturnProperties.Add(Constants.Properties.OutOfOffice.DestinationUser);
+            so.Methods.Add(listSharedUsers);
+
+            return new List<ServiceObject>() { so };
+        }
+
+        public override void Execute()
+        {
+            switch (base.ServiceBroker.Service.ServiceObjects[0].Methods[0].Name)
+            {
+                case Constants.Methods.OutOfOffice.GetUserStatus:
+                    GetUserStatus();
+                    break;
+                case Constants.Methods.OutOfOffice.SetInOffice:
+                    SetInOffice();
+                    break;
+                case Constants.Methods.OutOfOffice.SetOutOfOffice:
+                    SetOutOfOffice();
+                    break;
+                case Constants.Methods.OutOfOffice.AddOutOfOffice:
+                    AddOutOfOffice();
+                    break;
+                case Constants.Methods.OutOfOffice.ListSharedUsers:
+                    ListSharedUsers();
+                    break;
+            }
+        }
+
+        private void GetUserStatus()
+        {
+            string userFQN = base.GetStringProperty(Constants.Properties.OutOfOffice.UserFQN);
+
+            ServiceObject serviceObject = base.ServiceBroker.Service.ServiceObjects[0];
+            serviceObject.Properties.InitResultTable();
+            DataTable results = base.ServiceBroker.ServicePackage.ResultTable;
+
+            WorkflowManagementServer mngServer = new WorkflowManagementServer();
+
+            using (mngServer.CreateConnection())
+            {
+                mngServer.Open(BaseAPIConnectionString);  
+                UserStatuses status = mngServer.GetUserStatus(userFQN);
+
+                DataRow dr = results.NewRow();
+                dr[Constants.Properties.OutOfOffice.UserFQN] = userFQN;
+                dr[Constants.Properties.OutOfOffice.UserStatus] = status.ToString();
+
+                results.Rows.Add(dr);
+            }
+        }
+
+        private void SetInOffice()
+        {
+            string userFQN = base.GetStringProperty(Constants.Properties.OutOfOffice.UserFQN);
+
+            ServiceObject serviceObject = base.ServiceBroker.Service.ServiceObjects[0];
+            serviceObject.Properties.InitResultTable();
+            DataTable results = base.ServiceBroker.ServicePackage.ResultTable;
+
+            WorkflowManagementServer mngServer = new WorkflowManagementServer();
+
+            using (mngServer.CreateConnection())
+            {
+                mngServer.Open(BaseAPIConnectionString);
+                // None for userstatus means the users is not configured, throw an exception
+                if (UserStatuses.None == mngServer.GetUserStatus(userFQN))
+                    throw new ApplicationException(Constants.ErrorMessages.OutOfOfficeNotConfiguredForUser);
+                
+                bool result = mngServer.SetUserStatus(userFQN, UserStatuses.Available);
+
+
+                DataRow dr = results.NewRow();
+                dr[Constants.Properties.OutOfOffice.UserFQN] = userFQN;
+                dr[Constants.Properties.OutOfOffice.CallSuccess] = result;
+                results.Rows.Add(dr);
+            }
+        }
+
+      
+        private void SetOutOfOffice()
+        {
+            string userFQN = base.GetStringProperty(Constants.Properties.OutOfOffice.UserFQN);
+
+            ServiceObject serviceObject = base.ServiceBroker.Service.ServiceObjects[0];
+            serviceObject.Properties.InitResultTable();
+            DataTable results = base.ServiceBroker.ServicePackage.ResultTable;
+
+            WorkflowManagementServer mngServer = new WorkflowManagementServer();
+
+            using (mngServer.CreateConnection())
+            {
+                mngServer.Open(BaseAPIConnectionString);
+
+                // None for userstatus means the users is not configured, throw an exception
+                if (UserStatuses.None == mngServer.GetUserStatus(userFQN))
+                    throw new ApplicationException(Constants.ErrorMessages.OutOfOfficeNotConfiguredForUser);
+
+                bool result = mngServer.SetUserStatus(userFQN, UserStatuses.OOF);
+                DataRow dr = results.NewRow();
+                dr[Constants.Properties.OutOfOffice.UserFQN] = userFQN;
+                dr[Constants.Properties.OutOfOffice.CallSuccess] = result;
+                results.Rows.Add(dr);
+            }
+        }
+
+        // Example from page - http://help.k2.com/onlinehelp/k2blackpearl/DevRef/4.6.9/default.htm#How_to_set_a_users_Out_of_Office_Status.html%3FTocPath%3DRuntime%2520APIs%2520and%2520Services%7CWorkflow%7CWorkflow%2520Client%2520API%7CWorkflow%2520Client%2520API%2520Samples%7C_____10
+
+        private void AddOutOfOffice()
+        {
+            string userFQN = base.GetStringProperty(Constants.Properties.OutOfOffice.UserFQN);
+            string destinationUser = base.GetStringProperty(Constants.Properties.OutOfOffice.DestinationUser);
+
+            ServiceObject serviceObject = base.ServiceBroker.Service.ServiceObjects[0];
+            serviceObject.Properties.InitResultTable();
+            DataTable results = base.ServiceBroker.ServicePackage.ResultTable;
+
+            WorkflowManagementServer mngServer = new WorkflowManagementServer();
+
+            using (mngServer.CreateConnection())
+            {
+                mngServer.Open(BaseAPIConnectionString);
+
+                WorklistShares wsColl = mngServer.GetCurrentSharingSettings(userFQN, ShareType.OOF);
+
+                //  Throw error if multiple configurations (WorklistShare objects) detected, as this method cannot support that
+                if (wsColl.Count > 1)
+                {
+                    throw new ApplicationException(Constants.ErrorMessages.MultipleOOFConfigurations);
+                }
+
+                //  If configuration exist already, add to it
+                if (wsColl.Count == 1)
+                {
+                    
+                    WorklistShare worklistshare = wsColl[0];
+                    worklistshare.WorkTypes[0].Destinations.Add(new Destination(destinationUser, DestinationType.User));
+                    bool result = mngServer.ShareWorkList(userFQN, worklistshare);
+
+                    DataRow dr = results.NewRow();
+                    dr[Constants.Properties.OutOfOffice.UserFQN] = userFQN;
+                    dr[Constants.Properties.OutOfOffice.DestinationUser] = destinationUser;
+                    dr[Constants.Properties.OutOfOffice.CallSuccess] = result;
+                    results.Rows.Add(dr); ;
+
+                }
+                // New user, create configuration for OOF
+                else
+                {
+                    // ALL Work that remains which does not form part of any "WorkTypeException" Filter 
+                    WorklistCriteria worklistcriteria = new WorklistCriteria();
+                    worklistcriteria.Platform = "ASP";
+
+                    // Send ALL Work based on the above Filter to the following User 
+                    Destinations worktypedestinations = new Destinations();
+                    worktypedestinations.Add(new Destination(destinationUser, DestinationType.User));
+
+                    // Link the filters and destinations to the Work 
+                    WorkType worktype = new WorkType("MyWork", worklistcriteria, worktypedestinations);
+
+                    WorklistShare worklistshare = new WorklistShare();
+                    worklistshare.ShareType = ShareType.OOF;
+                    worklistshare.WorkTypes.Add(worktype);
+
+                    bool result = mngServer.ShareWorkList(userFQN, worklistshare);
+                    mngServer.SetUserStatus(userFQN, UserStatuses.Available);
+
+                    DataRow dr = results.NewRow();
+                    dr[Constants.Properties.OutOfOffice.UserFQN] = userFQN;
+                    dr[Constants.Properties.OutOfOffice.DestinationUser] = destinationUser;
+                    dr[Constants.Properties.OutOfOffice.CallSuccess] = result;
+                    results.Rows.Add(dr);
+                }
+                 
+            }
+        }
+        
+        private void ListSharedUsers()
+        {
+            string userFQN = base.GetStringProperty(Constants.Properties.OutOfOffice.UserFQN);
+
+            ServiceObject serviceObject = base.ServiceBroker.Service.ServiceObjects[0];
+            serviceObject.Properties.InitResultTable();
+            DataTable results = base.ServiceBroker.ServicePackage.ResultTable;
+
+            WorkflowManagementServer mngServer = new WorkflowManagementServer();
+            
+            using (mngServer.CreateConnection())
+            {
+                mngServer.Open(BaseAPIConnectionString);
+
+                // None for userstatus means the users is not configured, throw an exception
+                if (UserStatuses.None == mngServer.GetUserStatus(userFQN))
+                    throw new ApplicationException(Constants.ErrorMessages.OutOfOfficeNotConfiguredForUser);
+                                
+                WorklistShares wsColl = mngServer.GetCurrentSharingSettings(userFQN, ShareType.OOF);
+
+                foreach (WorklistShare ws in wsColl)
+                {
+                    //throw new ApplicationException("collection count is: "+ wsColl.Count.ToString());
+                    foreach (WorkType wt in ws.WorkTypes)
+                    {
+                        foreach (Destination dest in wt.Destinations)
+                        {
+                            DataRow dr = results.NewRow();
+                            dr[Constants.Properties.OutOfOffice.DestinationUser] = dest.Name.ToString();
+                            results.Rows.Add(dr);
+                        }
+                    }
+                }
+                
+            }
+        }
+    }
+}

--- a/K2Field.K2NE.ServiceBroker/ServiceObjects/ProcessInstanceManagementSO.cs
+++ b/K2Field.K2NE.ServiceBroker/ServiceObjects/ProcessInstanceManagementSO.cs
@@ -44,19 +44,19 @@ namespace K2Field.K2NE.ServiceBroker
          
             ServiceObject so = Helper.CreateServiceObject("ProcessInstanceManagement", "Exposes functionality to manage a process instances.");
 
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ProcessInstanceManagement.ActivityName, SoType.Text, "The name of the activity."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ProcessInstanceManagement.ProcessInstanceId, SoType.Number, "The process instance ID."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ProcessInstanceManagement.ProcessFolio, SoType.Text, "The folio to use for the process."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ProcessInstanceManagement.ProcessName, SoType.Text, "The full name of the process.")); 
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ProcessInstanceManagement.ProcessVersion, SoType.Number, "The full name of the process."));
-            so.Properties.Add(Helper.CreateProperty(Constants.Properties.ProcessInstanceManagement.StartSync, SoType.YesNo, "Start the process synchronously or not."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ProcessInstanceManagement.ActivityName, SoType.Text, "The name of the activity."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ProcessInstanceManagement.ProcessInstanceId, SoType.Number, "The process instance ID."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ProcessInstanceManagement.ProcessFolio, SoType.Text, "The folio to use for the process."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ProcessInstanceManagement.ProcessName, SoType.Text, "The full name of the process.")); 
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ProcessInstanceManagement.ProcessVersion, SoType.Number, "The full name of the process."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.ProcessInstanceManagement.StartSync, SoType.YesNo, "Start the process synchronously or not."));
 
             Method gotoActivity = Helper.CreateMethod(Constants.Methods.ProcessInstanceManagement.GotoActivity, "Move a process instance to a given activity.", MethodType.Execute);
             gotoActivity.InputProperties.Add(Constants.Properties.ProcessInstanceManagement.ActivityName);
             gotoActivity.InputProperties.Add(Constants.Properties.ProcessInstanceManagement.ProcessInstanceId);
             gotoActivity.Validation.RequiredProperties.Add(Constants.Properties.ProcessInstanceManagement.ProcessInstanceId);
             gotoActivity.Validation.RequiredProperties.Add(Constants.Properties.ProcessInstanceManagement.ActivityName);
-            so.Methods.Add(gotoActivity);
+            so.Methods.Create(gotoActivity);
 
             Method startProcessInstance = Helper.CreateMethod(Constants.Methods.ProcessInstanceManagement.StartProcessInstance, "Start a new process instance", MethodType.Create);
             startProcessInstance.InputProperties.Add(Constants.Properties.ProcessInstanceManagement.ProcessName);
@@ -66,7 +66,7 @@ namespace K2Field.K2NE.ServiceBroker
             startProcessInstance.Validation.RequiredProperties.Add(Constants.Properties.ProcessInstanceManagement.ProcessName);
             startProcessInstance.ReturnProperties.Add(Constants.Properties.ProcessInstanceManagement.ProcessInstanceId);
             startProcessInstance.ReturnProperties.Add(Constants.Properties.ProcessInstanceManagement.ProcessFolio);
-            so.Methods.Add(startProcessInstance);
+            so.Methods.Create(startProcessInstance);
 
             return new List<ServiceObject>() { so };
         }

--- a/K2Field.K2NE.ServiceBroker/ServiceObjects/RoleSO.cs
+++ b/K2Field.K2NE.ServiceBroker/ServiceObjects/RoleSO.cs
@@ -27,13 +27,13 @@ namespace K2Field.K2NE.ServiceBroker
             ServiceObject soRoleItem = Helper.CreateServiceObject("RoleManagement", "K2 Role management (add/remove/list K2 roles)");
 
 
-            soRoleItem.Properties.Add(Helper.CreateProperty(Constants.Properties.Role.RoleName, SoType.Text, "The name of the role to manage."));
-            soRoleItem.Properties.Add(Helper.CreateProperty(Constants.Properties.Role.RoleItemType, SoType.Text, "The type of role item (Group, User, SmartObject)."));
-            soRoleItem.Properties.Add(Helper.CreateProperty(Constants.Properties.Role.RoleExclude, SoType.YesNo, "Excluded role item."));
-            soRoleItem.Properties.Add(Helper.CreateProperty(Constants.Properties.Role.RoleItem, SoType.Text, "The FQN name of the role item."));
-            soRoleItem.Properties.Add(Helper.CreateProperty(Constants.Properties.Role.RoleDescription, SoType.Text, "A short description of the role."));
-            soRoleItem.Properties.Add(Helper.CreateProperty(Constants.Properties.Role.RoleItem, SoType.Text, "The FQN name of the role item."));
-            soRoleItem.Properties.Add(Helper.CreateProperty(Constants.Properties.Role.RoleDynamic, SoType.YesNo, "Is a role dynamic?"));
+            soRoleItem.Properties.Create(Helper.CreateProperty(Constants.Properties.Role.RoleName, SoType.Text, "The name of the role to manage."));
+            soRoleItem.Properties.Create(Helper.CreateProperty(Constants.Properties.Role.RoleItemType, SoType.Text, "The type of role item (Group, User, SmartObject)."));
+            soRoleItem.Properties.Create(Helper.CreateProperty(Constants.Properties.Role.RoleExclude, SoType.YesNo, "Excluded role item."));
+            soRoleItem.Properties.Create(Helper.CreateProperty(Constants.Properties.Role.RoleItem, SoType.Text, "The FQN name of the role item."));
+            soRoleItem.Properties.Create(Helper.CreateProperty(Constants.Properties.Role.RoleDescription, SoType.Text, "A short description of the role."));
+            soRoleItem.Properties.Create(Helper.CreateProperty(Constants.Properties.Role.RoleItem, SoType.Text, "The FQN name of the role item."));
+            soRoleItem.Properties.Create(Helper.CreateProperty(Constants.Properties.Role.RoleDynamic, SoType.YesNo, "Is a role dynamic?"));
 
             Method addRoleItem = Helper.CreateMethod(Constants.Methods.Role.AddRoleItem, "Add a RoleItem to a role" ,MethodType.Create);
             addRoleItem.InputProperties.Add(Constants.Properties.Role.RoleName);
@@ -43,7 +43,7 @@ namespace K2Field.K2NE.ServiceBroker
             addRoleItem.Validation.RequiredProperties.Add(Constants.Properties.Role.RoleName);
             addRoleItem.Validation.RequiredProperties.Add(Constants.Properties.Role.RoleItem);
             addRoleItem.Validation.RequiredProperties.Add(Constants.Properties.Role.RoleItemType);
-            soRoleItem.Methods.Add(addRoleItem);
+            soRoleItem.Methods.Create(addRoleItem);
 
 
             Method deleteRoleItem = Helper.CreateMethod(Constants.Methods.Role.RemoveRoleItem, "Remove a RoleItem from a role", MethodType.Delete);
@@ -52,14 +52,14 @@ namespace K2Field.K2NE.ServiceBroker
             deleteRoleItem.Validation.RequiredProperties.Add(Constants.Properties.Role.RoleName);
             deleteRoleItem.Validation.RequiredProperties.Add(Constants.Properties.Role.RoleItem);
 
-            soRoleItem.Methods.Add(deleteRoleItem);
+            soRoleItem.Methods.Create(deleteRoleItem);
 
             Method listRoleItems = Helper.CreateMethod(Constants.Methods.Role.ListRoleItem, "List the RoleItems in a role", MethodType.List);
             listRoleItems.InputProperties.Add(Constants.Properties.Role.RoleName);
             listRoleItems.ReturnProperties.Add(Constants.Properties.Role.RoleItem);
             listRoleItems.ReturnProperties.Add(Constants.Properties.Role.RoleExclude);
             listRoleItems.ReturnProperties.Add(Constants.Properties.Role.RoleItemType);
-            soRoleItem.Methods.Add(listRoleItems);
+            soRoleItem.Methods.Create(listRoleItems);
 
 
             Method addRole = Helper.CreateMethod(Constants.Methods.Role.AddRole, "Add K2 Role to K2 system", MethodType.Create);
@@ -71,18 +71,18 @@ namespace K2Field.K2NE.ServiceBroker
             addRole.Validation.RequiredProperties.Add(Constants.Properties.Role.RoleName);
             addRole.Validation.RequiredProperties.Add(Constants.Properties.Role.RoleItem);
             addRole.Validation.RequiredProperties.Add(Constants.Properties.Role.RoleItemType);
-            soRoleItem.Methods.Add(addRole);
+            soRoleItem.Methods.Create(addRole);
 
             Method removeRole = Helper.CreateMethod(Constants.Methods.Role.RemoveRole, "Remove K2 Role to K2 system", MethodType.Delete);
             removeRole.InputProperties.Add(Constants.Properties.Role.RoleName);
             removeRole.Validation.RequiredProperties.Add(Constants.Properties.Role.RoleName);
-            soRoleItem.Methods.Add(removeRole);
+            soRoleItem.Methods.Create(removeRole);
 
             Method listRoles = Helper.CreateMethod(Constants.Methods.Role.ListRoles, "list all K2 Roles", MethodType.List);
             listRoles.ReturnProperties.Add(Constants.Properties.Role.RoleName);
             listRoles.ReturnProperties.Add(Constants.Properties.Role.RoleDescription);
             listRoles.ReturnProperties.Add(Constants.Properties.Role.RoleDynamic);
-            soRoleItem.Methods.Add(listRoles);
+            soRoleItem.Methods.Create(listRoles);
 
             return new List<ServiceObject>() {soRoleItem};
 

--- a/K2Field.K2NE.ServiceBroker/ServiceObjects/WorkingHoursConfigurationSO.cs
+++ b/K2Field.K2NE.ServiceBroker/ServiceObjects/WorkingHoursConfigurationSO.cs
@@ -1,0 +1,547 @@
+﻿using System;
+using System.Data;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using SourceCode.Workflow.Management;
+using SourceCode.SmartObjects.Services.ServiceSDK.Objects;
+using SourceCode.SmartObjects.Services.ServiceSDK.Types;
+using System.Text.RegularExpressions;
+
+namespace K2Field.K2NE.ServiceBroker
+{
+    public class WorkingHoursConfigurationSO : ServiceObjectBase
+    {
+        public WorkingHoursConfigurationSO(K2NEServiceBroker api) : base(api) { }
+
+        public override string ServiceFolder
+        {
+            get
+            {
+                return "Management API";
+            }
+        }
+
+        public override List<ServiceObject> DescribeServiceObjects()
+        {
+            ServiceObject so = Helper.CreateServiceObject("WorkingHoursConfiguration", "Service Object that exposes the Working Hours Configuration of the K2 server.");
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.WorkingHoursConfiguration.DefaultZone, SoType.YesNo, "Shows if the zone is default"));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.WorkingHoursConfiguration.Description, SoType.Memo, "Used for description of various objects."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.WorkingHoursConfiguration.DurationHours, SoType.Number, "Hours for a timespan."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.WorkingHoursConfiguration.DurationMinutes, SoType.Number, "Minutes for a timespan."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.WorkingHoursConfiguration.DurationSeconds, SoType.Number, "Seconds for a timespan."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.WorkingHoursConfiguration.GMTOffset, SoType.Number, "Time zone - from -13 to +13."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.WorkingHoursConfiguration.IsNonWorkDate, SoType.YesNo, "Sets or shows if the day is working or not."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.WorkingHoursConfiguration.TimeOfDayHours, SoType.Number, "Hours for a timespan for time of a day."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.WorkingHoursConfiguration.TimeOfDayMinutes, SoType.Number, "Minutes for a timespan for time of a day."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.WorkingHoursConfiguration.TimeOfDaySeconds, SoType.Number, "Seconds for a timespan for time of a day."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.WorkingHoursConfiguration.WorkDate, SoType.DateTime, "Date of the exception date - workdate."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.WorkingHoursConfiguration.WorkDay, SoType.Text, "Day of the week: Monday, Tuesday, Wednesday etc."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.WorkingHoursConfiguration.ZoneGUID, SoType.Guid, "GUID of the zone."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.WorkingHoursConfiguration.ZoneName, SoType.Text, "Name of the zone."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.WorkingHoursConfiguration.NewZoneName, SoType.Text, "New name of the existing zone."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.WorkingHoursConfiguration.FQN, SoType.Text, "FQN of users from a zone."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.WorkingHoursConfiguration.UserName, SoType.Text, "UserName of users from a zone."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.WorkingHoursConfiguration.ZoneExists, SoType.YesNo, "Does a zone exist."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.WorkingHoursConfiguration.StartDateTime, SoType.DateTime, "Starting datetime."));
+            so.Properties.Create(Helper.CreateProperty(Constants.Properties.WorkingHoursConfiguration.FinishDateTime, SoType.DateTime, "Finishing datetime."));
+
+            Method createZone = Helper.CreateMethod(Constants.Methods.WorkingHoursConfiguration.CreateZone, "Creates a new Zone", MethodType.Create);
+            createZone.InputProperties.Add(Constants.Properties.WorkingHoursConfiguration.ZoneName);
+            createZone.InputProperties.Add(Constants.Properties.WorkingHoursConfiguration.Description);
+            createZone.InputProperties.Add(Constants.Properties.WorkingHoursConfiguration.GMTOffset);
+            createZone.InputProperties.Add(Constants.Properties.WorkingHoursConfiguration.DefaultZone);
+            createZone.Validation.RequiredProperties.Add(Constants.Properties.WorkingHoursConfiguration.ZoneName);
+            createZone.Validation.RequiredProperties.Add(Constants.Properties.WorkingHoursConfiguration.GMTOffset);
+            so.Methods.Create(createZone);
+
+            Method saveZone = Helper.CreateMethod(Constants.Methods.WorkingHoursConfiguration.SaveZone, "Updates an existing zone", MethodType.Update);
+            saveZone.InputProperties.Add(Constants.Properties.WorkingHoursConfiguration.ZoneName);
+            saveZone.InputProperties.Add(Constants.Properties.WorkingHoursConfiguration.NewZoneName);
+            saveZone.InputProperties.Add(Constants.Properties.WorkingHoursConfiguration.Description);
+            saveZone.InputProperties.Add(Constants.Properties.WorkingHoursConfiguration.GMTOffset);
+            saveZone.InputProperties.Add(Constants.Properties.WorkingHoursConfiguration.DefaultZone);
+            saveZone.Validation.RequiredProperties.Add(Constants.Properties.WorkingHoursConfiguration.ZoneName);
+            so.Methods.Create(saveZone);
+
+            Method deleteZone = Helper.CreateMethod(Constants.Methods.WorkingHoursConfiguration.DeleteZone, "Deletes an existing zone", MethodType.Delete);
+            deleteZone.InputProperties.Add(Constants.Properties.WorkingHoursConfiguration.ZoneName);
+            deleteZone.Validation.RequiredProperties.Add(Constants.Properties.WorkingHoursConfiguration.ZoneName);
+            so.Methods.Create(deleteZone);
+
+            Method loadZone = Helper.CreateMethod(Constants.Methods.WorkingHoursConfiguration.LoadZone, "Loads an existing zone", MethodType.Read);
+            loadZone.InputProperties.Add(Constants.Properties.WorkingHoursConfiguration.ZoneName);
+            loadZone.Validation.RequiredProperties.Add(Constants.Properties.WorkingHoursConfiguration.ZoneName);
+            loadZone.ReturnProperties.Add(Constants.Properties.WorkingHoursConfiguration.ZoneName);
+            loadZone.ReturnProperties.Add(Constants.Properties.WorkingHoursConfiguration.Description);
+            loadZone.ReturnProperties.Add(Constants.Properties.WorkingHoursConfiguration.GMTOffset);
+            loadZone.ReturnProperties.Add(Constants.Properties.WorkingHoursConfiguration.DefaultZone);
+            so.Methods.Create(loadZone);
+
+            Method listZones = Helper.CreateMethod(Constants.Methods.WorkingHoursConfiguration.ListZones, "Lists all existing zones", MethodType.List);
+            listZones.ReturnProperties.Add(Constants.Properties.WorkingHoursConfiguration.ZoneName);
+            so.Methods.Create(listZones);
+
+            Method listZoneUsers = Helper.CreateMethod(Constants.Methods.WorkingHoursConfiguration.ListZoneUsers, "Lists all users for a certain zone", MethodType.List);
+            listZoneUsers.InputProperties.Add(Constants.Properties.WorkingHoursConfiguration.ZoneName);
+            listZoneUsers.Validation.RequiredProperties.Add(Constants.Properties.WorkingHoursConfiguration.ZoneName);
+            listZoneUsers.ReturnProperties.Add(Constants.Properties.WorkingHoursConfiguration.FQN);
+            listZoneUsers.ReturnProperties.Add(Constants.Properties.WorkingHoursConfiguration.UserName);
+            so.Methods.Create(listZoneUsers);
+
+            Method getDefaultZone = Helper.CreateMethod(Constants.Methods.WorkingHoursConfiguration.GetDefaultZone, "Gets the name of the default zone", MethodType.Read);
+            getDefaultZone.ReturnProperties.Add(Constants.Properties.WorkingHoursConfiguration.ZoneName);
+            so.Methods.Create(getDefaultZone);
+
+            Method setDefaultZone = Helper.CreateMethod(Constants.Methods.WorkingHoursConfiguration.SetDefaultZone, "Sets the zone as a default one", MethodType.Execute);
+            setDefaultZone.InputProperties.Add(Constants.Properties.WorkingHoursConfiguration.ZoneName);
+            setDefaultZone.Validation.RequiredProperties.Add(Constants.Properties.WorkingHoursConfiguration.ZoneName);
+            so.Methods.Create(setDefaultZone);
+
+            Method zoneExists = Helper.CreateMethod(Constants.Methods.WorkingHoursConfiguration.ZoneExists, "Returns true or false if a zone exists", MethodType.Execute);
+            zoneExists.InputProperties.Add(Constants.Properties.WorkingHoursConfiguration.ZoneName);
+            zoneExists.Validation.RequiredProperties.Add(Constants.Properties.WorkingHoursConfiguration.ZoneName);
+            zoneExists.ReturnProperties.Add(Constants.Properties.WorkingHoursConfiguration.ZoneExists);
+            so.Methods.Create(zoneExists);
+
+            Method zoneCalculateEvent = Helper.CreateMethod(Constants.Methods.WorkingHoursConfiguration.ZoneCalculateEvent, "Adding working hours of a zone to datetime", MethodType.Execute);
+            zoneCalculateEvent.InputProperties.Add(Constants.Properties.WorkingHoursConfiguration.ZoneName);
+            zoneCalculateEvent.InputProperties.Add(Constants.Properties.WorkingHoursConfiguration.StartDateTime);
+            zoneCalculateEvent.InputProperties.Add(Constants.Properties.WorkingHoursConfiguration.DurationHours);
+            zoneCalculateEvent.InputProperties.Add(Constants.Properties.WorkingHoursConfiguration.DurationMinutes);
+            zoneCalculateEvent.InputProperties.Add(Constants.Properties.WorkingHoursConfiguration.DurationSeconds);
+            zoneCalculateEvent.Validation.RequiredProperties.Add(Constants.Properties.WorkingHoursConfiguration.ZoneName);
+            zoneCalculateEvent.Validation.RequiredProperties.Add(Constants.Properties.WorkingHoursConfiguration.StartDateTime);
+            zoneCalculateEvent.ReturnProperties.Add(Constants.Properties.WorkingHoursConfiguration.FinishDateTime);
+            so.Methods.Create(zoneCalculateEvent);
+
+            Method userSetZone = Helper.CreateMethod(Constants.Methods.WorkingHoursConfiguration.UserSetZone, "Associate user with a certain zone", MethodType.Execute);
+            userSetZone.InputProperties.Add(Constants.Properties.WorkingHoursConfiguration.FQN);
+            userSetZone.InputProperties.Add(Constants.Properties.WorkingHoursConfiguration.ZoneName);
+            userSetZone.Validation.RequiredProperties.Add(Constants.Properties.WorkingHoursConfiguration.ZoneName);
+            userSetZone.Validation.RequiredProperties.Add(Constants.Properties.WorkingHoursConfiguration.FQN);
+            so.Methods.Create(userSetZone);
+
+            Method userGetZone = Helper.CreateMethod(Constants.Methods.WorkingHoursConfiguration.UserGetZone, "Gets the associated zone of a user", MethodType.Read);
+            userGetZone.InputProperties.Add(Constants.Properties.WorkingHoursConfiguration.FQN);
+            userGetZone.ReturnProperties.Add(Constants.Properties.WorkingHoursConfiguration.ZoneName);
+            so.Methods.Create(userGetZone);
+
+            Method userDeleteZone = Helper.CreateMethod(Constants.Methods.WorkingHoursConfiguration.UserDeleteZone, "Deletes the associated zone of a user", MethodType.Execute);
+            userDeleteZone.InputProperties.Add(Constants.Properties.WorkingHoursConfiguration.FQN);
+            so.Methods.Create(userDeleteZone);
+
+            Method userCalculateEvent = Helper.CreateMethod(Constants.Methods.WorkingHoursConfiguration.UserCalculateEvent, "Adding working hours of a user zone to datetime", MethodType.Execute);
+            userCalculateEvent.InputProperties.Add(Constants.Properties.WorkingHoursConfiguration.FQN);
+            userCalculateEvent.InputProperties.Add(Constants.Properties.WorkingHoursConfiguration.StartDateTime);
+            userCalculateEvent.InputProperties.Add(Constants.Properties.WorkingHoursConfiguration.DurationHours);
+            userCalculateEvent.InputProperties.Add(Constants.Properties.WorkingHoursConfiguration.DurationMinutes);
+            userCalculateEvent.InputProperties.Add(Constants.Properties.WorkingHoursConfiguration.DurationSeconds);
+            userCalculateEvent.Validation.RequiredProperties.Add(Constants.Properties.WorkingHoursConfiguration.FQN);
+            userCalculateEvent.Validation.RequiredProperties.Add(Constants.Properties.WorkingHoursConfiguration.StartDateTime);
+            userCalculateEvent.ReturnProperties.Add(Constants.Properties.WorkingHoursConfiguration.FinishDateTime);
+            so.Methods.Create(userCalculateEvent);
+            
+            return new List<ServiceObject> { so };
+        }
+
+        public override void Execute()
+        {
+            switch (base.ServiceBroker.Service.ServiceObjects[0].Methods[0].Name)
+            {
+                case Constants.Methods.WorkingHoursConfiguration.CreateZone:
+                    CreateZone();
+                    break;
+                case Constants.Methods.WorkingHoursConfiguration.DeleteZone:
+                    DeleteZone();
+                    break;
+                case Constants.Methods.WorkingHoursConfiguration.LoadZone:
+                    LoadZone();
+                    break;
+                case Constants.Methods.WorkingHoursConfiguration.SaveZone:
+                    SaveZone();
+                    break;
+                case Constants.Methods.WorkingHoursConfiguration.ListZones:
+                    ListZones();
+                    break;
+                case Constants.Methods.WorkingHoursConfiguration.ListZoneUsers:
+                    ListZoneUsers();
+                    break;
+                case Constants.Methods.WorkingHoursConfiguration.GetDefaultZone:
+                    GetDefaultZone();
+                    break;
+                case Constants.Methods.WorkingHoursConfiguration.SetDefaultZone:
+                    SetDefaultZone();
+                    break;
+                case Constants.Methods.WorkingHoursConfiguration.ZoneExists:
+                    ZoneExists();
+                    break;
+                case Constants.Methods.WorkingHoursConfiguration.ZoneCalculateEvent:
+                    ZoneCalculateEvent();
+                    break;
+                case Constants.Methods.WorkingHoursConfiguration.UserSetZone:
+                    UserSetZone();
+                    break;
+                case Constants.Methods.WorkingHoursConfiguration.UserGetZone:
+                    UserGetZone();
+                    break;
+                case Constants.Methods.WorkingHoursConfiguration.UserDeleteZone:
+                    UserDeleteZone();
+                    break;
+                case Constants.Methods.WorkingHoursConfiguration.UserCalculateEvent:
+                    UserCalculateEvent();
+                    break;
+            }
+
+        }
+
+        private void CreateZone()
+        {
+            string ZoneName = base.GetStringProperty(Constants.Properties.WorkingHoursConfiguration.ZoneName, true);
+            string Description = base.GetStringProperty(Constants.Properties.WorkingHoursConfiguration.Description);
+            int GmtOffSet = base.GetIntProperty(Constants.Properties.WorkingHoursConfiguration.GMTOffset, true);
+            bool DefaultZone = base.GetBoolProperty(Constants.Properties.WorkingHoursConfiguration.DefaultZone);
+
+            WorkflowManagementServer mngServer = new WorkflowManagementServer();
+            using (mngServer.CreateConnection())
+            {
+                mngServer.Open(BaseAPIConnectionString);
+
+                if (!Helper.SpecialCharactersExist(ZoneName))
+                {
+                    throw new ApplicationException(Constants.ErrorMessages.SpecialCharactersAreNotAllowed);
+                }
+                else if (mngServer.ZoneExists(ZoneName))
+                {
+                    throw new ApplicationException(Constants.ErrorMessages.ZoneExists + ZoneName + ".");
+                }
+                else if (GmtOffSet > 13 || GmtOffSet < -13)
+                {
+                    throw new ApplicationException(Constants.ErrorMessages.GMTOffSetValidationFailed);
+                }
+                else
+                {
+                    AvailabilityZone aZone = new AvailabilityZone();
+                    aZone.ZoneName = ZoneName;
+                    aZone.ID = Guid.NewGuid();
+                    aZone.ZoneDescription = Description;
+                    aZone.ZoneGMTOffset = GmtOffSet;
+                    aZone.DefaultZone = DefaultZone;
+
+                    mngServer.ZoneCreateNew(aZone);
+                }                    
+            }
+        }
+        private void SaveZone()
+        {
+            string CurrentZoneName = base.GetStringProperty(Constants.Properties.WorkingHoursConfiguration.ZoneName, true);
+            string NewZoneName = base.GetStringProperty(Constants.Properties.WorkingHoursConfiguration.NewZoneName);
+            Property DescriptionProperty = ServiceBroker.Service.ServiceObjects[0].Properties[Constants.Properties.WorkingHoursConfiguration.Description];
+            Property GMTOffsetProperty = ServiceBroker.Service.ServiceObjects[0].Properties[Constants.Properties.WorkingHoursConfiguration.GMTOffset];
+            int GmtOffSet = base.GetIntProperty(Constants.Properties.WorkingHoursConfiguration.GMTOffset);
+            bool DefaultZone = base.GetBoolProperty(Constants.Properties.WorkingHoursConfiguration.DefaultZone);
+
+            WorkflowManagementServer mngServer = new WorkflowManagementServer();
+            using (mngServer.CreateConnection())
+            {
+                mngServer.Open(BaseAPIConnectionString);
+
+                if (!String.IsNullOrEmpty(NewZoneName) && !Helper.SpecialCharactersExist(NewZoneName))
+                {
+                    throw new ApplicationException(Constants.ErrorMessages.SpecialCharactersAreNotAllowed);
+                }
+                else if (!String.IsNullOrEmpty(NewZoneName) && mngServer.ZoneExists(NewZoneName))
+                {
+                    throw new ApplicationException(Constants.ErrorMessages.ZoneExists + NewZoneName + ".");
+                }
+                else if (!mngServer.ZoneExists(CurrentZoneName))
+                {
+                    throw new ApplicationException(Constants.ErrorMessages.ZoneDoesNotExist + CurrentZoneName + ".");
+                }
+                else if (GmtOffSet > 13 || GmtOffSet < -13)
+                {
+                    throw new ApplicationException(Constants.ErrorMessages.GMTOffSetValidationFailed);
+                }
+                else
+                {
+                    AvailabilityZone aZone = mngServer.ZoneLoad(CurrentZoneName);
+                    aZone.ZoneName = String.IsNullOrEmpty(NewZoneName) ? CurrentZoneName : NewZoneName;
+                    if ((DescriptionProperty.Value != null) || (DescriptionProperty.IsClear))
+                    {
+                        aZone.ZoneDescription = DescriptionProperty.Value == null ? String.Empty : DescriptionProperty.Value as string;
+                    }
+                    if ((GmtOffSet != 0) || (GMTOffsetProperty.IsClear))
+                    {
+                        aZone.ZoneGMTOffset = GmtOffSet;
+                    }
+                    aZone.DefaultZone = DefaultZone; //even if the value is false, you cannot make a zone nonDefault without setting other zone to default
+                    mngServer.ZoneSave(CurrentZoneName, aZone);
+                }
+            }
+
+        }
+        private void DeleteZone()
+        {
+            string ZoneName = base.GetStringProperty(Constants.Properties.WorkingHoursConfiguration.ZoneName, true);
+            
+            WorkflowManagementServer mngServer = new WorkflowManagementServer();
+            using (mngServer.CreateConnection())
+            {
+                mngServer.Open(BaseAPIConnectionString);
+
+                if (!mngServer.ZoneExists(ZoneName))
+                {
+                    throw new ApplicationException(Constants.ErrorMessages.ZoneDoesNotExist + ZoneName + ".");
+                }
+                else
+                {
+                    mngServer.ZoneDelete(ZoneName);
+                }
+            }
+
+        }
+        private void LoadZone()
+        {
+            string ZoneName = base.GetStringProperty(Constants.Properties.WorkingHoursConfiguration.ZoneName, true);
+            base.ServiceBroker.Service.ServiceObjects[0].Properties.InitResultTable();
+            DataTable results = base.ServiceBroker.ServicePackage.ResultTable;
+
+            WorkflowManagementServer mngServer = new WorkflowManagementServer();
+            using (mngServer.CreateConnection())
+            {
+                mngServer.Open(BaseAPIConnectionString);
+
+                if (!mngServer.ZoneExists(ZoneName))
+                {
+                    throw new ApplicationException(Constants.ErrorMessages.ZoneDoesNotExist + ZoneName + ".");
+                }
+                else
+                {
+                    AvailabilityZone aZone = mngServer.ZoneLoad(ZoneName);
+                    DataRow dRow = results.NewRow();
+                    dRow[Constants.Properties.WorkingHoursConfiguration.ZoneName] = aZone.ZoneName;
+                    dRow[Constants.Properties.WorkingHoursConfiguration.DefaultZone] = aZone.DefaultZone;
+                    dRow[Constants.Properties.WorkingHoursConfiguration.GMTOffset] = aZone.ZoneGMTOffset;
+                    dRow[Constants.Properties.WorkingHoursConfiguration.Description] = aZone.ZoneDescription;
+                    results.Rows.Add(dRow);
+                }
+            }        
+        }
+        private void ListZones()
+        {
+            base.ServiceBroker.Service.ServiceObjects[0].Properties.InitResultTable();
+            DataTable results = base.ServiceBroker.ServicePackage.ResultTable;
+            WorkflowManagementServer mngServer = new WorkflowManagementServer();
+            using (mngServer.CreateConnection())
+            {
+                mngServer.Open(BaseAPIConnectionString);
+                List<string> zoneList = mngServer.ZoneListAll();
+                foreach (string zone in zoneList)
+                {
+                    DataRow dRow = results.NewRow();
+                    dRow[Constants.Properties.WorkingHoursConfiguration.ZoneName] = zone;
+                    results.Rows.Add(dRow);
+                }
+            }        
+        }
+        private void ListZoneUsers()
+        {
+            string ZoneName = base.GetStringProperty(Constants.Properties.WorkingHoursConfiguration.ZoneName, true);
+            base.ServiceBroker.Service.ServiceObjects[0].Properties.InitResultTable();
+            DataTable results = base.ServiceBroker.ServicePackage.ResultTable;
+
+            WorkflowManagementServer mngServer = new WorkflowManagementServer();
+            using (mngServer.CreateConnection())
+            {
+                mngServer.Open(BaseAPIConnectionString);
+                if (!mngServer.ZoneExists(ZoneName))
+                {
+                    throw new ApplicationException(Constants.ErrorMessages.ZoneDoesNotExist + ZoneName + ".");
+                }
+                else
+                {
+                    List<string> userList = mngServer.ZoneListUsers(ZoneName);
+                    foreach (string user in userList)
+                    {
+                        DataRow dRow = results.NewRow();
+                        dRow[Constants.Properties.WorkingHoursConfiguration.FQN] = user;
+                        dRow[Constants.Properties.WorkingHoursConfiguration.UserName] = Helper.DeleteLabel(user);
+                        results.Rows.Add(dRow);
+                    }
+                }
+            }        
+        }
+        private void GetDefaultZone()
+        {
+            base.ServiceBroker.Service.ServiceObjects[0].Properties.InitResultTable();
+            DataTable results = base.ServiceBroker.ServicePackage.ResultTable;
+
+            WorkflowManagementServer mngServer = new WorkflowManagementServer();
+            using (mngServer.CreateConnection())
+            {
+                mngServer.Open(BaseAPIConnectionString);
+                string defaultZone = mngServer.ZoneGetDefault();
+
+                DataRow dRow = results.NewRow();
+                dRow[Constants.Properties.WorkingHoursConfiguration.ZoneName] = defaultZone;
+                results.Rows.Add(dRow);                
+            }     
+        }
+        private void SetDefaultZone()
+        {
+            string ZoneName = base.GetStringProperty(Constants.Properties.WorkingHoursConfiguration.ZoneName, true);
+                        
+            WorkflowManagementServer mngServer = new WorkflowManagementServer();
+            using (mngServer.CreateConnection())
+            {
+                mngServer.Open(BaseAPIConnectionString);
+                if (!mngServer.ZoneExists(ZoneName))
+                {
+                    throw new ApplicationException(Constants.ErrorMessages.ZoneDoesNotExist + ZoneName + ".");
+                }
+                else
+                {
+                    mngServer.ZoneSetDefault(ZoneName);
+                }
+            }        
+        }
+        private void ZoneExists()
+        {
+            string ZoneName = base.GetStringProperty(Constants.Properties.WorkingHoursConfiguration.ZoneName, true);
+            base.ServiceBroker.Service.ServiceObjects[0].Properties.InitResultTable();
+            DataTable results = base.ServiceBroker.ServicePackage.ResultTable;
+
+            WorkflowManagementServer mngServer = new WorkflowManagementServer();
+            using (mngServer.CreateConnection())
+            {
+                mngServer.Open(BaseAPIConnectionString);                
+                DataRow dRow = results.NewRow();
+                dRow[Constants.Properties.WorkingHoursConfiguration.ZoneExists] = mngServer.ZoneExists(ZoneName);
+                results.Rows.Add(dRow);
+            }        
+        }
+        private void ZoneCalculateEvent()
+        {
+            string ZoneName = base.GetStringProperty(Constants.Properties.WorkingHoursConfiguration.ZoneName, true);
+            string Start = base.GetStringProperty(Constants.Properties.WorkingHoursConfiguration.StartDateTime, true);
+            int DurationHours = base.GetIntProperty(Constants.Properties.WorkingHoursConfiguration.DurationHours);
+            int DurationMinutes = base.GetIntProperty(Constants.Properties.WorkingHoursConfiguration.DurationMinutes);
+            int DurationSeconds = base.GetIntProperty(Constants.Properties.WorkingHoursConfiguration.DurationSeconds);            
+
+            base.ServiceBroker.Service.ServiceObjects[0].Properties.InitResultTable();
+            DataTable results = base.ServiceBroker.ServicePackage.ResultTable;
+
+            WorkflowManagementServer mngServer = new WorkflowManagementServer();
+            using (mngServer.CreateConnection())
+            {
+                mngServer.Open(BaseAPIConnectionString);
+                if (!mngServer.ZoneExists(ZoneName))
+                {
+                    throw new ApplicationException(Constants.ErrorMessages.ZoneDoesNotExist + ZoneName + ".");
+                }
+                else
+                {
+                    TimeSpan Duration = new TimeSpan(DurationHours, DurationMinutes, DurationSeconds);
+
+                    DateTime dt;
+                    if (!DateTime.TryParse(Start, out dt))
+                    {
+                        throw new ApplicationException(Constants.ErrorMessages.DateNotValid);
+                    }
+
+                    AvailabilityZone zone = mngServer.ZoneLoad(ZoneName);
+                    if (zone.AvailabilityHoursList == null || zone.AvailabilityHoursList.Count == 0)
+                    {
+                        throw new ApplicationException(Constants.ErrorMessages.WorkingHoursNotSet);
+                    }
+
+                    DataRow dRow = results.NewRow();
+                    dRow[Constants.Properties.WorkingHoursConfiguration.FinishDateTime] = mngServer.ZoneCalculateEvent(ZoneName, dt, Duration);
+                    results.Rows.Add(dRow);
+                }
+            }
+        }
+        private void UserSetZone()
+        {
+            string ZoneName = base.GetStringProperty(Constants.Properties.WorkingHoursConfiguration.ZoneName, true);
+            string FQN = base.GetStringProperty(Constants.Properties.WorkingHoursConfiguration.FQN, true);
+            
+            WorkflowManagementServer mngServer = new WorkflowManagementServer();
+            using (mngServer.CreateConnection())
+            {
+                mngServer.Open(BaseAPIConnectionString);
+                if (!mngServer.ZoneExists(ZoneName))
+                {
+                    throw new ApplicationException(Constants.ErrorMessages.ZoneDoesNotExist + ZoneName + ".");
+                }
+                else
+                {
+                    mngServer.UserSetZone(FQN, ZoneName);
+                }
+            }
+
+        }
+        private void UserGetZone()
+        {
+            string FQN = base.GetStringProperty(Constants.Properties.WorkingHoursConfiguration.FQN, true);
+            base.ServiceBroker.Service.ServiceObjects[0].Properties.InitResultTable();
+            DataTable results = base.ServiceBroker.ServicePackage.ResultTable;
+
+            WorkflowManagementServer mngServer = new WorkflowManagementServer();
+            using (mngServer.CreateConnection())
+            {
+                mngServer.Open(BaseAPIConnectionString);
+                DataRow dRow = results.NewRow();
+                dRow[Constants.Properties.WorkingHoursConfiguration.ZoneName] = mngServer.UserGetZone(FQN);
+                results.Rows.Add(dRow);                
+            }
+        }
+        private void UserDeleteZone()
+        {
+            string FQN = base.GetStringProperty(Constants.Properties.WorkingHoursConfiguration.FQN, true);
+            
+            WorkflowManagementServer mngServer = new WorkflowManagementServer();
+            using (mngServer.CreateConnection())
+            {
+                mngServer.Open(BaseAPIConnectionString);
+                mngServer.UserDeleteZone(FQN);                
+            }
+        }
+
+        private void UserCalculateEvent()
+        {
+            string FQN = base.GetStringProperty(Constants.Properties.WorkingHoursConfiguration.FQN, true);
+            string Start = base.GetStringProperty(Constants.Properties.WorkingHoursConfiguration.StartDateTime, true);
+            int DurationHours = base.GetIntProperty(Constants.Properties.WorkingHoursConfiguration.DurationHours);
+            int DurationMinutes = base.GetIntProperty(Constants.Properties.WorkingHoursConfiguration.DurationMinutes);
+            int DurationSeconds = base.GetIntProperty(Constants.Properties.WorkingHoursConfiguration.DurationSeconds);
+
+            base.ServiceBroker.Service.ServiceObjects[0].Properties.InitResultTable();
+            DataTable results = base.ServiceBroker.ServicePackage.ResultTable;
+
+            WorkflowManagementServer mngServer = new WorkflowManagementServer();
+            using (mngServer.CreateConnection())
+            {
+                mngServer.Open(BaseAPIConnectionString);
+
+                TimeSpan Duration = new TimeSpan(DurationHours, DurationMinutes, DurationSeconds);
+
+                DateTime dt;
+                if (!DateTime.TryParse(Start, out dt))
+                {
+                    throw new ApplicationException(Constants.ErrorMessages.DateNotValid);
+                }
+
+                AvailabilityZone zone = mngServer.ZoneLoad(mngServer.UserGetZone(FQN));
+                if (zone.AvailabilityHoursList == null || zone.AvailabilityHoursList.Count == 0)
+                {
+                    throw new ApplicationException(Constants.ErrorMessages.WorkingHoursNotSet);
+                }
+
+                DataRow dRow = results.NewRow();
+                dRow[Constants.Properties.WorkingHoursConfiguration.FinishDateTime] = mngServer.UserCalculateEvent(FQN, dt, Duration);
+                results.Rows.Add(dRow);                
+            }
+        }
+    }
+}

--- a/K2Field.K2NE.ServiceBroker/ServiceObjects/WorklistSO.cs
+++ b/K2Field.K2NE.ServiceBroker/ServiceObjects/WorklistSO.cs
@@ -25,38 +25,38 @@ namespace K2Field.K2NE.ServiceBroker
         {
             ServiceObject worklistSO = Helper.CreateServiceObject("Worklist", "ServiceObject that exposes the users worklist.");
 
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.ProcessName, SoType.Text, "The name of the process."));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.ProcessFolder, SoType.Text, "The folder in which the process resides."));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.ProcessFullname, SoType.Text, "The full name of the process (folder + \\ + name)."));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.ProcessDescription, SoType.Text, "A description of the process."));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.ProcessMetadata, SoType.Text, "Metadata defined in the process."));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.ProcessStatus, SoType.Text, "The current status of the process instance."));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.ProcessPriority, SoType.Number, "The current priority of the process instance."));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.ProcessStartdate, SoType.DateTime, "The start date of the process instance."));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.ProcessExpectedDuration, SoType.Number, "The expected duration for this process instance in seconds."));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.ProcessGuid, SoType.Guid, "The unique guid of the process instance."));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.ProcessId, SoType.Number, "The unique id of the process instance."));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.ActivityId, SoType.Number, "The unique id of the activity."));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.ActivityName, SoType.Text, "The name of the activity."));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.ActivityPriority, SoType.Text, "The current priority of the activity."));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.ActivityDescription, SoType.Text, "The description of the activity."));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.ActivityMetadata, SoType.Text, "The metadata defined on the activity."));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.ActivityStartdate, SoType.DateTime, "The start date of the activity instance."));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.ActivityExpectedDuration, SoType.Number, "The expected duration of the activity."));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.EventId, SoType.Text, "EventId"));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.EventName, SoType.Text, "EventName"));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.EventMetadata, SoType.Text, "EventMetadata"));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.EventDescription, SoType.Text, "EventDescription"));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.EventPriority, SoType.Text, "EventPriority"));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.EventStartDate, SoType.Text, "EventStartDate"));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.EventExpectedDuration, SoType.Text, "EventExpectedDuration"));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.WorklistItemStatus, SoType.Text, "WorklistItemStatus"));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.OriginalDestination, SoType.Text, "OriginalDestination"));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.Folio, SoType.Text, "Folio"));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.Data, SoType.Text, "Data"));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.SerialNumber, SoType.Text, "SerialNumber"));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.IncludeShared, SoType.YesNo, "Include Shared Tasks"));
-            worklistSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.ExcludeAllocated, SoType.YesNo, "Exclude Allocated Tasks"));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.ProcessName, SoType.Text, "The name of the process."));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.ProcessFolder, SoType.Text, "The folder in which the process resides."));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.ProcessFullname, SoType.Text, "The full name of the process (folder + \\ + name)."));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.ProcessDescription, SoType.Text, "A description of the process."));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.ProcessMetadata, SoType.Text, "Metadata defined in the process."));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.ProcessStatus, SoType.Text, "The current status of the process instance."));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.ProcessPriority, SoType.Number, "The current priority of the process instance."));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.ProcessStartdate, SoType.DateTime, "The start date of the process instance."));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.ProcessExpectedDuration, SoType.Number, "The expected duration for this process instance in seconds."));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.ProcessGuid, SoType.Guid, "The unique guid of the process instance."));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.ProcessId, SoType.Number, "The unique id of the process instance."));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.ActivityId, SoType.Number, "The unique id of the activity."));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.ActivityName, SoType.Text, "The name of the activity."));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.ActivityPriority, SoType.Text, "The current priority of the activity."));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.ActivityDescription, SoType.Text, "The description of the activity."));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.ActivityMetadata, SoType.Text, "The metadata defined on the activity."));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.ActivityStartdate, SoType.DateTime, "The start date of the activity instance."));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.ActivityExpectedDuration, SoType.Number, "The expected duration of the activity."));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.EventId, SoType.Text, "EventId"));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.EventName, SoType.Text, "EventName"));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.EventMetadata, SoType.Text, "EventMetadata"));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.EventDescription, SoType.Text, "EventDescription"));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.EventPriority, SoType.Text, "EventPriority"));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.EventStartDate, SoType.Text, "EventStartDate"));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.EventExpectedDuration, SoType.Text, "EventExpectedDuration"));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.WorklistItemStatus, SoType.Text, "WorklistItemStatus"));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.OriginalDestination, SoType.Text, "OriginalDestination"));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.Folio, SoType.Text, "Folio"));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.Data, SoType.Text, "Data"));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.SerialNumber, SoType.Text, "SerialNumber"));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.IncludeShared, SoType.YesNo, "Include Shared Tasks"));
+            worklistSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.ExcludeAllocated, SoType.YesNo, "Exclude Allocated Tasks"));
 
             Method getWorkload = Helper.CreateMethod(Constants.Methods.ClientWorklist.GetWorklist, "Provides a client's view of the user workload.", MethodType.List);
             // Input properties, will be used for an excact match in search, combined with 'AND'. Please note that the list is NOT the same as the ReturnProperties because not every field is filterable via API.
@@ -118,7 +118,7 @@ namespace K2Field.K2NE.ServiceBroker
             getWorkload.ReturnProperties.Add(Constants.Properties.ClientWorklist.Folio);
             getWorkload.ReturnProperties.Add(Constants.Properties.ClientWorklist.Data);
             getWorkload.ReturnProperties.Add(Constants.Properties.ClientWorklist.SerialNumber);
-            worklistSO.Methods.Add(getWorkload);
+            worklistSO.Methods.Create(getWorkload);
 
 
 
@@ -126,12 +126,12 @@ namespace K2Field.K2NE.ServiceBroker
             ServiceObject worklistItemSO = Helper.CreateServiceObject("WorklistItem", "Exposes functionality for a single worklistitem");
 
 
-            worklistItemSO.Properties.Add(Helper.CreateProperty(Constants.Properties.ClientWorklist.SerialNumber, SoType.Text, "SerialNumber"));
+            worklistItemSO.Properties.Create(Helper.CreateProperty(Constants.Properties.ClientWorklist.SerialNumber, SoType.Text, "SerialNumber"));
 
             Method releaseWorklistItem = Helper.CreateMethod(Constants.Methods.ClientWorklist.ReleaseWorklistItem, "Release a worklistitem.", MethodType.Execute);
             releaseWorklistItem.InputProperties.Add(Constants.Properties.ClientWorklist.SerialNumber);
             releaseWorklistItem.Validation.RequiredProperties.Add(Constants.Properties.ClientWorklist.SerialNumber);
-            worklistItemSO.Methods.Add(releaseWorklistItem);
+            worklistItemSO.Methods.Create(releaseWorklistItem);
 
 
 


### PR DESCRIPTION
Fixed some syntax errors, also reduced warnings to a minimum. The class WorkingHoursConfigurationSO.cs contains 2 methods, namely: ZoneCalculateEvent() and UserCalculateEvent(). These methods failed when they tried to convert
the string to a DateTime via Convert.ToDateTime(string). This was changed to DateTime.TryParse(string, out DateTime).
Also added checks to indicate the problem if there are no Working Hours set. This can be done in K2 Workspace.