### PR TITLE
Changes in Client API - Out of Office to prevent adding multiple entries for same destination user

### DIFF
--- a/K2Field.K2NE.ServiceBroker/ServiceObjects/Client API/OutOfOfficeClientSO.cs
+++ b/K2Field.K2NE.ServiceBroker/ServiceObjects/Client API/OutOfOfficeClientSO.cs
@@ -1,13 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using K2Field.K2NE.ServiceBroker.Helpers;
 using SourceCode.SmartObjects.Services.ServiceSDK.Objects;
 using SourceCode.SmartObjects.Services.ServiceSDK.Types;
 using System.Data;
-
-using SourceCode.Workflow.Management.OOF;
 using SourceCode.Workflow.Client;
 
 namespace K2Field.K2NE.ServiceBroker.ServiceObjects
@@ -155,7 +151,52 @@ namespace K2Field.K2NE.ServiceBroker.ServiceObjects
             {
                 k2Con.Open(base.K2ClientConnectionSetup);
 
-                
+                WorklistShares wsColl = k2Con.GetCurrentSharingSettings(ShareType.OOF);
+
+                //  Throw error if multiple configurations (WorklistShare objects) detected, as this method cannot support that 
+                if (wsColl.Count > 1)
+                {
+                    throw new ApplicationException(Constants.ErrorMessages.MultipleOOFConfigurations);
+                }
+
+
+                //  If configuration exist already, add to it 
+                else if (wsColl.Count == 1)
+                {
+
+
+                    WorklistShare worklistshare = wsColl[0];
+
+                    int capacity = worklistshare.WorkTypes[0].Destinations.Count;
+
+                    string[] existingDestinations = new string[capacity];
+
+                    for (int i = 0; i < capacity; i++)
+                    {
+                        existingDestinations[i] = worklistshare.WorkTypes[0].Destinations[i].Name.ToUpper().Trim();
+                    }
+
+                    if (Array.IndexOf(existingDestinations, destinationUser.ToUpper().Trim()) == -1)
+                    {
+                        worklistshare.WorkTypes[0].Destinations.Add(new Destination(destinationUser, DestinationType.User));
+                    }
+
+                    bool result = k2Con.ShareWorkList(worklistshare);
+
+                    DataRow dr = results.NewRow();
+
+                    dr[Constants.SOProperties.OutOfOffice.DestinationUser] = destinationUser;
+
+                    results.Rows.Add(dr); ;
+
+
+                }
+                // New user, create configuration for OOF 
+                else
+                {
+
+
+
                     // ALL Work that remains which does not form part of any "WorkTypeException" Filter 
                     WorklistCriteria worklistcriteria = new WorklistCriteria();
                     worklistcriteria.Platform = "ASP";
@@ -165,7 +206,7 @@ namespace K2Field.K2NE.ServiceBroker.ServiceObjects
                     worktypedestinations.Add(new Destination(destinationUser, DestinationType.User));
 
                     // Link the filters and destinations to the Work 
-                    WorkType worktype = new WorkType("MyWork", worklistcriteria, worktypedestinations);
+                    WorkType worktype = new WorkType("MyWork_" + k2Con.User.FQN, worklistcriteria, worktypedestinations);
 
                     WorklistShare worklistshare = new WorklistShare();
                     worklistshare.ShareType = ShareType.OOF;
@@ -179,7 +220,8 @@ namespace K2Field.K2NE.ServiceBroker.ServiceObjects
                     dr[Constants.SOProperties.OutOfOffice.DestinationUser] = destinationUser;
 
                     results.Rows.Add(dr);
-                
+
+                }
 
                 k2Con.Close();
             }


### PR DESCRIPTION
As K2 API does not prevent adding multiple shares to same destination, check if the destination already exist for new user share has been done manually.