### PR TITLE
Changes to the activity name assignment

### DIFF
--- a/K2Field.K2NE.ServiceBroker/ServiceObjects/Client API/WorklistSO.cs
+++ b/K2Field.K2NE.ServiceBroker/ServiceObjects/Client API/WorklistSO.cs
@@ -192,7 +192,7 @@ namespace K2Field.K2NE.ServiceBroker.ServiceObjects.Client_API
                 WorklistCriteria wc = new WorklistCriteria();
                 wc.Platform = base.Platform;
                 wc.AddFilterField(WCField.ProcessID, WCCompare.Equal, processInstanceId);
-                wc.AddFilterField(WCLogical.And, WCField.ActivityName, WCCompare.Equal, activityName);
+                wc.AddFilterField(WCLogical.And, WCField.ActivityDisplayName, WCCompare.Equal, activityName);
                 Worklist wl = k2Con.OpenWorklist(wc);
 
                 if (wl.TotalCount == 0)
@@ -312,7 +312,7 @@ namespace K2Field.K2NE.ServiceBroker.ServiceObjects.Client_API
             dr[Constants.SOProperties.ClientWorklist.ProcessGuid] = wli.ProcessInstance.Guid;
             dr[Constants.SOProperties.ClientWorklist.ProcessId] = wli.ProcessInstance.ID;
             dr[Constants.SOProperties.ClientWorklist.ActivityId] = wli.ActivityInstanceDestination.ID;
-            dr[Constants.SOProperties.ClientWorklist.ActivityName] = wli.ActivityInstanceDestination.Name;
+            dr[Constants.SOProperties.ClientWorklist.ActivityName] = wli.ActivityInstanceDestination.DisplayName;
             dr[Constants.SOProperties.ClientWorklist.ActivityPriority] = wli.ActivityInstanceDestination.Priority;
             dr[Constants.SOProperties.ClientWorklist.ActivityDescription] = wli.ActivityInstanceDestination.Description;
             dr[Constants.SOProperties.ClientWorklist.ActivityMetadata] = wli.ActivityInstanceDestination.MetaData;
@@ -346,7 +346,7 @@ namespace K2Field.K2NE.ServiceBroker.ServiceObjects.Client_API
                 {WCField.ProcessStartDate, Constants.SOProperties.ClientWorklist.ProcessStartdate},
                 {WCField.ProcessExpectedDuration, Constants.SOProperties.ClientWorklist.ProcessExpectedDuration},
                 {WCField.ProcessID, Constants.SOProperties.ClientWorklist.ProcessId},
-                {WCField.ActivityName, Constants.SOProperties.ClientWorklist.ActivityName},
+                {WCField.ActivityDisplayName, Constants.SOProperties.ClientWorklist.ActivityName},
                 {WCField.ActivityPriority, Constants.SOProperties.ClientWorklist.ActivityPriority},
                 {WCField.ActivityDescription, Constants.SOProperties.ClientWorklist.ActivityDescription},
                 {WCField.ActivityMetaData, Constants.SOProperties.ClientWorklist.ActivityMetadata},

--- a/K2Field.K2NE.ServiceBroker/ServiceObjects/Management API/ManagementWorklistSO.cs
+++ b/K2Field.K2NE.ServiceBroker/ServiceObjects/Management API/ManagementWorklistSO.cs
@@ -35,7 +35,6 @@ namespace K2Field.K2NE.ServiceBroker.ServiceObjects
                 case Constants.Methods.ManagementWorklist.RedirectWorklistItem:
                     RedirectWorklistItem();
                     break;
-
                 case Constants.Methods.ManagementWorklist.ReleaseWorklistItem:
                     ReleaseWorklistItem();
                     break;
@@ -136,7 +135,7 @@ namespace K2Field.K2NE.ServiceBroker.ServiceObjects
             r[Constants.SOProperties.ManagementWorklist.ActivityId] = wlItem.ActID;
             r[Constants.SOProperties.ManagementWorklist.ActivityInstanceDestinationId] = wlItem.ActInstDestID;
             r[Constants.SOProperties.ManagementWorklist.ActivityInstanceId] = wlItem.ActInstID;
-            r[Constants.SOProperties.ManagementWorklist.ActivityName] = wlItem.ActivityName;
+            r[Constants.SOProperties.ManagementWorklist.ActivityName] = wlItem.ActivityDisplayName;
             r[Constants.SOProperties.ManagementWorklist.Destination] = wlItem.Destination;
             //TODO: r[CoProperties.ManagementWorklistProperty.DestinationType] = wlItem.;
             r[Constants.SOProperties.ManagementWorklist.EventId] = wlItem.EventID;

--- a/K2Field.K2NE.ServiceBroker/ServiceObjects/Management API/ProcessInstanceManagementSO.cs
+++ b/K2Field.K2NE.ServiceBroker/ServiceObjects/Management API/ProcessInstanceManagementSO.cs
@@ -128,7 +128,7 @@ namespace K2Field.K2NE.ServiceBroker.ServiceObjects
                         continue;
                     DataRow row = results.NewRow();
                     row[Constants.SOProperties.ProcessInstanceManagement.ActivityID] = actvt.ID;
-                    row[Constants.SOProperties.ProcessInstanceManagement.ActivityName] = actvt.Name;
+                    row[Constants.SOProperties.ProcessInstanceManagement.ActivityName] = actvt.DisplayName;
                     row[Constants.SOProperties.ProcessInstanceManagement.ActivityDescription] = actvt.Description;
                     row[Constants.SOProperties.ProcessInstanceManagement.ActivityExpectedDuration] = actvt.ExpectedDuration;
                     row[Constants.SOProperties.ProcessInstanceManagement.IsStartActivity] = actvt.IsStart;


### PR DESCRIPTION
Configured the service objects to use the activity display name and not the activity name.