### PR TITLE
Add GetIdentityAndContainersDelimited method

### DIFF
--- a/K2Field.K2NE.ServiceBroker/Constants/Methods.cs
+++ b/K2Field.K2NE.ServiceBroker/Constants/Methods.cs
@@ -124,10 +124,12 @@ namespace K2Field.K2NE.ServiceBroker.Constants
             public const string GetGroupDetails = "UMRGetGroupDetails";
             public const string GetGroups = "UMRGetGroups";
             public const string FindUserGroups = "UMRFindUserGroups";
+            public const string GetGroupsFQNDelimited = "URMGetGroupsFQNDelimited";
         }
         public static class User
         {
             public const string GetUsers = "UMRGetUsers";
+            public const string GetUsersFQNDelimited = "URMGetUsersFQNDelimited";
         }
 
         public static class PowershellVariables

--- a/K2Field.K2NE.ServiceBroker/Constants/Methods.cs
+++ b/K2Field.K2NE.ServiceBroker/Constants/Methods.cs
@@ -42,6 +42,7 @@ namespace K2Field.K2NE.ServiceBroker.Constants
             public const string ResolveGroupIdentity = "ResolveGroupIdentity";
             public const string ResolveRoleIdentity = "ResolveRoleIdentity";
             public const string GetIdentities = "GetEmailFromIdentity";
+            public const string GetIdentityAndContainersDelimited = "GetIdentityAndContainersDelimited";
         }
 
         public static class ProcessInstanceManagement
@@ -128,8 +129,7 @@ namespace K2Field.K2NE.ServiceBroker.Constants
         }
         public static class User
         {
-            public const string GetUsers = "UMRGetUsers";
-            public const string GetUsersFQNDelimited = "URMGetUsersFQNDelimited";
+            public const string GetUsers = "UMRGetUsers";            
         }
 
         public static class PowershellVariables

--- a/K2Field.K2NE.ServiceBroker/Constants/Methods.cs
+++ b/K2Field.K2NE.ServiceBroker/Constants/Methods.cs
@@ -124,7 +124,7 @@ namespace K2Field.K2NE.ServiceBroker.Constants
             public const string GetGroupDetails = "UMRGetGroupDetails";
             public const string GetGroups = "UMRGetGroups";
             public const string FindUserGroups = "UMRFindUserGroups";
-            public const string GetGroupsFQNDelimited = "URMGetGroupsFQNDelimited";
+            public const string FindUserGroupsFQNDelimited = "URMFindUserGroupsFQNDelimited";
         }
         public static class User
         {

--- a/K2Field.K2NE.ServiceBroker/Constants/SOProperties.cs
+++ b/K2Field.K2NE.ServiceBroker/Constants/SOProperties.cs
@@ -108,6 +108,7 @@ namespace K2Field.K2NE.ServiceBroker.Constants
             public const string CurrentPrincipalName = "CurrentPrincipalName";
             public const string CurrentPrincipalIdentityType = "CurrentPrincipalIdentityType";
             public const string FQN = "FQN";
+            public const string DelimitedFQNs = "DelimitedValues";
             public const string ResolveContainers = "ResolveContainers";
             public const string ResolveMembers = "ResolveMembers";
             public const string IdentityDescription = "UserDescription";
@@ -133,6 +134,7 @@ namespace K2Field.K2NE.ServiceBroker.Constants
             public const string UserCultureNumberFormat = "UserCultureNumberFormat";
             public const string K2ImpersonateUser = "K2ImpersonateUser";
             public const string UseCache = "UseCache";
+            public const string Delimiter = "Delimiter";
         }
 
         public static class ProcessInstanceManagement
@@ -227,7 +229,6 @@ namespace K2Field.K2NE.ServiceBroker.Constants
             public const string DisplayName = "DisplayName";
             public const string SipAccount = "SipAccount";
             public const string ObjectSid = "ObjectSID";
-            public const string Delimiter = "Delimiter";
         }
 
         public static class PowershellVariables

--- a/K2Field.K2NE.ServiceBroker/Constants/SOProperties.cs
+++ b/K2Field.K2NE.ServiceBroker/Constants/SOProperties.cs
@@ -227,6 +227,7 @@ namespace K2Field.K2NE.ServiceBroker.Constants
             public const string DisplayName = "DisplayName";
             public const string SipAccount = "SipAccount";
             public const string ObjectSid = "ObjectSID";
+            public const string Delimiter = "Delimiter";
         }
 
         public static class PowershellVariables

--- a/K2Field.K2NE.ServiceBroker/ServiceObjects/URM/GroupSO.cs
+++ b/K2Field.K2NE.ServiceBroker/ServiceObjects/URM/GroupSO.cs
@@ -73,14 +73,6 @@ namespace K2Field.K2NE.ServiceBroker.ServiceObjects.URM
             }
             soGroup.Methods.Add(getGroups);
 
-            Method findUserGroupsDelimited = Helper.CreateMethod(Constants.Methods.Group.FindUserGroupsFQNDelimited, "Get delimited groups FQN", MethodType.Read);
-            findUserGroupsDelimited.ReturnProperties.Add(Constants.SOProperties.URM.FQN);
-            findUserGroupsDelimited.MethodParameters.Create(Helper.CreateParameter(Constants.SOProperties.URM.Label, SoType.Text, true, "Label"));
-            findUserGroupsDelimited.MethodParameters.Create(Helper.CreateParameter(Constants.SOProperties.URM.UserName, SoType.Text, true, "UserName"));
-            findUserGroupsDelimited.MethodParameters.Create(Helper.CreateParameter(Constants.SOProperties.URM.Delimiter, SoType.Text, true, "Delimiter"));
-            soGroup.Methods.Add(findUserGroupsDelimited);
-
-
             return new List<ServiceObject>() { soGroup };
         }
 
@@ -93,9 +85,6 @@ namespace K2Field.K2NE.ServiceBroker.ServiceObjects.URM
                     break;
                 case Constants.Methods.Group.GetGroups:
                     GetGroups();
-                    break;
-                case Constants.Methods.Group.FindUserGroupsFQNDelimited:
-                    FindUserGroupsDelimited();
                     break;
             }
         }
@@ -225,40 +214,6 @@ namespace K2Field.K2NE.ServiceBroker.ServiceObjects.URM
             }
         }
 
-        private void FindUserGroupsDelimited()
-        {
-            string[] ldaps = LDAPPaths.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-            string[] netbioses = NetBiosNames.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-            string securityLabel = GetStringParameter(Constants.SOProperties.URM.Label, true);
-            string userName = GetStringParameter(Constants.SOProperties.URM.UserName, true);
-            string delimiter = GetStringParameter(Constants.SOProperties.URM.Delimiter, true);
-            ServiceBroker.Service.ServiceObjects[0].Properties.InitResultTable();
-            DataTable dtResults = ServiceBroker.ServicePackage.ResultTable;
-
-            FQName fqn = new FQName(securityLabel, userName);
-
-            ICachedIdentity userIdentity = ServiceBroker.IdentityService.GetIdentityFromName(fqn, IdentityType.User, null);
-            ICollection<ICachedIdentity> groupIdentities = ServiceBroker.IdentityService.GetIdentityContainers(userIdentity, IdentitySearchOptions.Groups);
-            if (groupIdentities == null)
-            {
-                return;
-            }
-            string delimitedFQNs = "";
-            foreach (ICachedIdentity groupIdentity in groupIdentities)
-            {
-                if (groupIdentity.Type == IdentityType.Group)
-                {
-                    delimitedFQNs += groupIdentity.FullyQualifiedName.FQN + delimiter;
-                }
-            }
-
-            string trimmedString = delimitedFQNs.Remove(delimitedFQNs.LastIndexOf(delimiter));
-            DataRow dRow = dtResults.NewRow();
-            dRow[Constants.SOProperties.URM.FQN] = trimmedString;
-            dtResults.Rows.Add(dRow);
-        }
-
-
         private void RunUMGetGroups(string ldap, string net)
         {
             Dictionary<string, string> inputProperties = new Dictionary<string, string>()
@@ -318,7 +273,6 @@ namespace K2Field.K2NE.ServiceBroker.ServiceObjects.URM
                 }
             }
         }
-
         
     }
 }

--- a/K2Field.K2NE.ServiceBroker/ServiceObjects/URM/GroupSO.cs
+++ b/K2Field.K2NE.ServiceBroker/ServiceObjects/URM/GroupSO.cs
@@ -73,6 +73,13 @@ namespace K2Field.K2NE.ServiceBroker.ServiceObjects.URM
             }
             soGroup.Methods.Add(getGroups);
 
+            Method findUserGroupsDelimited = Helper.CreateMethod(Constants.Methods.Group.FindUserGroupsFQNDelimited, "Get delimited groups FQN", MethodType.Read);
+            findUserGroupsDelimited.ReturnProperties.Add(Constants.SOProperties.URM.FQN);
+            findUserGroupsDelimited.MethodParameters.Create(Helper.CreateParameter(Constants.SOProperties.URM.Label, SoType.Text, true, "Label"));
+            findUserGroupsDelimited.MethodParameters.Create(Helper.CreateParameter(Constants.SOProperties.URM.UserName, SoType.Text, true, "UserName"));
+            findUserGroupsDelimited.MethodParameters.Create(Helper.CreateParameter(Constants.SOProperties.URM.Delimiter, SoType.Text, true, "Delimiter"));
+            soGroup.Methods.Add(findUserGroupsDelimited);
+
 
             return new List<ServiceObject>() { soGroup };
         }
@@ -86,6 +93,9 @@ namespace K2Field.K2NE.ServiceBroker.ServiceObjects.URM
                     break;
                 case Constants.Methods.Group.GetGroups:
                     GetGroups();
+                    break;
+                case Constants.Methods.Group.FindUserGroupsFQNDelimited:
+                    FindUserGroupsDelimited();
                     break;
             }
         }
@@ -215,6 +225,40 @@ namespace K2Field.K2NE.ServiceBroker.ServiceObjects.URM
             }
         }
 
+        private void FindUserGroupsDelimited()
+        {
+            string[] ldaps = LDAPPaths.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            string[] netbioses = NetBiosNames.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            string securityLabel = GetStringParameter(Constants.SOProperties.URM.Label, true);
+            string userName = GetStringParameter(Constants.SOProperties.URM.UserName, true);
+            string delimiter = GetStringParameter(Constants.SOProperties.URM.Delimiter, true);
+            ServiceBroker.Service.ServiceObjects[0].Properties.InitResultTable();
+            DataTable dtResults = ServiceBroker.ServicePackage.ResultTable;
+
+            FQName fqn = new FQName(securityLabel, userName);
+
+            ICachedIdentity userIdentity = ServiceBroker.IdentityService.GetIdentityFromName(fqn, IdentityType.User, null);
+            ICollection<ICachedIdentity> groupIdentities = ServiceBroker.IdentityService.GetIdentityContainers(userIdentity, IdentitySearchOptions.Groups);
+            if (groupIdentities == null)
+            {
+                return;
+            }
+            string delimitedFQNs = "";
+            foreach (ICachedIdentity groupIdentity in groupIdentities)
+            {
+                if (groupIdentity.Type == IdentityType.Group)
+                {
+                    delimitedFQNs += groupIdentity.FullyQualifiedName.FQN + delimiter;
+                }
+            }
+
+            string trimmedString = delimitedFQNs.Remove(delimitedFQNs.LastIndexOf(delimiter));
+            DataRow dRow = dtResults.NewRow();
+            dRow[Constants.SOProperties.URM.FQN] = trimmedString;
+            dtResults.Rows.Add(dRow);
+        }
+
+
         private void RunUMGetGroups(string ldap, string net)
         {
             Dictionary<string, string> inputProperties = new Dictionary<string, string>()
@@ -274,5 +318,7 @@ namespace K2Field.K2NE.ServiceBroker.ServiceObjects.URM
                 }
             }
         }
+
+        
     }
 }


### PR DESCRIPTION
Hi,

I added a new method, which can be used for lots of applications. It returns a delimited (i.e. serialized) list of a user FQN + all FQNs of his containers. I find this extremely useful because with its help you can build your own User/Role management functions in SQL or another system. Fore example, I can create Application Roles and assign K2 Roles and/or AD Groups as members to those roles. Then receiving all user Containers, I can implement a custom logic to check if a user OR any of their containers belong to a certain role etc.
Previously to get the user Groups and Roles we had to access K2 DB - Identity.Identity. But if an application DB is hosted on another SQL Server, then this is not possible. K2 currently does not have an SMO or a method that could return the same values.
If the necessity of the method is not clear, please, let me know and I will explain more.

Thanks in advance.