### PR TITLE
ADO Helper with a new Join method

### DIFF
--- a/Documentation/ADOHelper.adoc
+++ b/Documentation/ADOHelper.adoc
@@ -1,0 +1,9 @@
+== ADO Helper
+
+This Service Object will contain all helper functions, which can be used for data conversion/transformation, that is returned from ADO.NET query.
+
+
+=== Join method - main features:
+* You can provide a delimiter, which should be used to delimit the functions
+* ADO.NET query is a preferred way of extracting the data from SMO, because simply specifying SMO and Method name, a user cannot set custom filtering and sorting options
+* The query always joins the first returned property/column of the DataTable, received from the ADO.NET query.  

--- a/K2Field.K2NE.ServiceBroker/Constants/Methods.cs
+++ b/K2Field.K2NE.ServiceBroker/Constants/Methods.cs
@@ -5,18 +5,23 @@ namespace K2Field.K2NE.ServiceBroker.Constants
 
     public static class Methods
     {
-        public static class ErrorLog
-        {
-            public const string GetErrors = "GetErrors";
-            public const string RetryProcess = "RetryProcessInstance";
-        }
-        
         public static class ADOSMOQuery
         {
             public const string ExcelFromADOQuery = "ExcelFromADOQuery";
             public const string ListQueryData = "List";
             public const string ADOQuery2Excel = "ADOQueryToExcel";
         }
+        public static class ADOHelper
+        {
+            public const string Join = "Join";
+        }
+
+        public static class ErrorLog
+        {
+            public const string GetErrors = "GetErrors";
+            public const string RetryProcess = "RetryProcessInstance";
+        }      
+        
 
         public static class ManagementWorklist
         {

--- a/K2Field.K2NE.ServiceBroker/Constants/SOProperties.cs
+++ b/K2Field.K2NE.ServiceBroker/Constants/SOProperties.cs
@@ -8,6 +8,14 @@ namespace K2Field.K2NE.ServiceBroker.Constants
 {
     public static partial class SOProperties
     {
+
+        public static class ADOHelper
+        {
+            public const string ADOQuery = "ADOQuery";
+            public const string Delimiter = "Delimiter";
+            public const string Result = "Result";
+        }
+
         public static class ErrorLog
         {
             public const string Profile = "Profile";

--- a/K2Field.K2NE.sln
+++ b/K2Field.K2NE.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30501.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "K2Field.K2NE.ServiceBroker", "K2Field.K2NE.ServiceBroker\K2Field.K2NE.ServiceBroker.csproj", "{5D45A104-69BD-4B55-A255-9BCC629D62DF}"
 EndProject
@@ -14,6 +14,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Files", "Solution 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentation", "{E9C2E02B-FB7A-49D5-A540-0404B7C69DA9}"
 	ProjectSection(SolutionItems) = preProject
+		ADOHelper.adoc = ADOHelper.adoc
 		Documentation\ADOSMOQuery.adoc = Documentation\ADOSMOQuery.adoc
 		Documentation\ADOSMOQuery.SampleQueries.xml = Documentation\ADOSMOQuery.SampleQueries.xml
 		Documentation\ChangeLog.adoc = Documentation\ChangeLog.adoc


### PR DESCRIPTION
Hi,

Upon Mark's request :) I added a new ServiceObject, which can later be extended with some helper functions. Currently it already contains 1 function - that joins a property, returned from the ADO.NET query. A user can specify a delimiter to receive a delimited string.

Konstantin