### PR TITLE
Update Install.ps1

### DIFF
--- a/Installer/Install.ps1
+++ b/Installer/Install.ps1
@@ -15,7 +15,7 @@ Function GetK2Version([string]$machine = $env:computername) {
     $reg = [Microsoft.Win32.RegistryKey]::OpenRemoteBaseKey([Microsoft.Win32.RegistryHive]::LocalMachine, $machine)
     $regKey= $reg.OpenSubKey($registryKeyLocation)
     $installVer = $regKey.GetValue($registryKeyName)
-    return [Version]$installVer.Major
+    return ([Version]$installVer).Major
 }
 
 Function StartK2Service() {


### PR DESCRIPTION
Installer Script seems to not recognize Five and fails when trying to start/stop the K2 Server service.  Line below should fix this bug, or at least does for me locally.